### PR TITLE
Added support for target servers

### DIFF
--- a/apigee_edge.go
+++ b/apigee_edge.go
@@ -56,6 +56,7 @@ type ApigeeClient struct {
   Organization     OrganizationService
   Caches           CachesService
 	Options          ApigeeClientOptions
+	TargetServers TargetserversService
 
   // Account           AccountService
   // Actions           ActionsService
@@ -201,6 +202,7 @@ func NewApigeeClient(o *ApigeeClientOptions) (*ApigeeClient,error) {
   c.Environments = &EnvironmentsServiceOp{client: c}
   c.Organization = &OrganizationServiceOp{client: c}
   c.Caches = &CachesServiceOp{client: c}
+	c.TargetServers = &TargetserversServiceOp{client: c}
   c.Options = *o;
 
   var e error = nil

--- a/apigee_edge.go
+++ b/apigee_edge.go
@@ -2,79 +2,79 @@
 package apigee
 
 import (
-  "bytes"
-  "encoding/json"
-  "fmt"
-  "os"
-  "path"
-  "errors"
-  "log"
-  "io"
-  "io/ioutil"
-  "net/http"
-  "net/http/httputil"
-  "net/url"
-  "reflect"
-  //"strconv"
-  //"time"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path"
+	"reflect"
+	//"strconv"
+	//"time"
 
-  "github.com/google/go-querystring/query"
-  "github.com/bgentry/go-netrc/netrc"
+	"github.com/bgentry/go-netrc/netrc"
+	"github.com/google/go-querystring/query"
 )
 
 const (
-  libraryVersion = "0.2.0"
-  defaultBaseURL = "https://api.enterprise.apigee.com/"
-  userAgent      = "go-apigee-edge/" + libraryVersion
-  appJson        = "application/json"
-  octetStream    = "application/octet-stream"
+	libraryVersion    = "0.2.0"
+	defaultBaseURL    = "https://api.enterprise.apigee.com/"
+	userAgent         = "go-apigee-edge/" + libraryVersion
+	appJson           = "application/json"
+	octetStream       = "application/octet-stream"
 	apiUriPathElement = "apis"
-	sfUriPathElement = "sharedflows"
-	DeploymentDelay = "20"
+	sfUriPathElement  = "sharedflows"
+	DeploymentDelay   = "20"
 )
 
 // ApigeeClient manages communication with Apigee V1 Admin API.
 type ApigeeClient struct {
-  // HTTP client used to communicate with the Edge API.
-  client *http.Client
+	// HTTP client used to communicate with the Edge API.
+	client *http.Client
 
-  auth *AdminAuth
-  debug bool
+	auth  *AdminAuth
+	debug bool
 
-  // Base URL for API requests.
-  BaseURL *url.URL
+	// Base URL for API requests.
+	BaseURL *url.URL
 
-  // User agent for client
-  UserAgent string
+	// User agent for client
+	UserAgent string
 
-  // Services used for communicating with the API
-  Proxies          ProxiesService
-  SharedFlows      SharedFlowsService
-  Products         ProductsService
-  Developers       DevelopersService
-  Environments     EnvironmentsService
-  Organization     OrganizationService
-  Caches           CachesService
-	Options          ApigeeClientOptions
+	// Services used for communicating with the API
+	Proxies       ProxiesService
+	SharedFlows   SharedFlowsService
+	Products      ProductsService
+	Developers    DevelopersService
+	Environments  EnvironmentsService
+	Organization  OrganizationService
+	Caches        CachesService
+	Options       ApigeeClientOptions
 	TargetServers TargetserversService
 
-  // Account           AccountService
-  // Actions           ActionsService
-  // Domains           DomainsService
-  // DropletActions    DropletActionsService
-  // Images            ImagesService
-  // ImageActions      ImageActionsService
-  // Keys              KeysService
-  // Regions           RegionsService
-  // Sizes             SizesService
-  // FloatingIPs       FloatingIPsService
-  // FloatingIPActions FloatingIPActionsService
-  // Storage           StorageService
-  // StorageActions    StorageActionsService
-  // Tags              TagsService
+	// Account           AccountService
+	// Actions           ActionsService
+	// Domains           DomainsService
+	// DropletActions    DropletActionsService
+	// Images            ImagesService
+	// ImageActions      ImageActionsService
+	// Keys              KeysService
+	// Regions           RegionsService
+	// Sizes             SizesService
+	// FloatingIPs       FloatingIPsService
+	// FloatingIPActions FloatingIPActionsService
+	// Storage           StorageService
+	// StorageActions    StorageActionsService
+	// Tags              TagsService
 
-  // Optional function called after every successful request made to the DO APIs
-  onRequestCompleted RequestCompletionCallback
+	// Optional function called after every successful request made to the DO APIs
+	onRequestCompleted RequestCompletionCallback
 }
 
 // RequestCompletionCallback defines the type of the request callback function
@@ -82,152 +82,149 @@ type RequestCompletionCallback func(*http.Request, *http.Response)
 
 // ListOptions holds optional parameters to various List methods
 type ListOptions struct {
-  // to ask for expanded results
-  Expand bool `url:"expand"`
+	// to ask for expanded results
+	Expand bool `url:"expand"`
 }
 
 // wrap the standard http.Response returned from Apigee Edge. (why?)
 type Response struct {
-  *http.Response
+	*http.Response
 }
 
 // An ErrorResponse reports the error caused by an API request
 type ErrorResponse struct {
-  // HTTP response that caused this error
-  Response *http.Response
+	// HTTP response that caused this error
+	Response *http.Response
 
-  // Error message - maybe the json for this is "fault"
-  Message string `json:"message"`
+	// Error message - maybe the json for this is "fault"
+	Message string `json:"message"`
 }
 
 func addOptions(s string, opt interface{}) (string, error) {
-  v := reflect.ValueOf(opt)
+	v := reflect.ValueOf(opt)
 
-  if v.Kind() == reflect.Ptr && v.IsNil() {
-    return s, nil
-  }
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		return s, nil
+	}
 
-  origURL, err := url.Parse(s)
-  if err != nil {
-    return s, err
-  }
+	origURL, err := url.Parse(s)
+	if err != nil {
+		return s, err
+	}
 
-  origValues := origURL.Query()
+	origValues := origURL.Query()
 
-  newValues, err := query.Values(opt)
-  if err != nil {
-    return s, err
-  }
+	newValues, err := query.Values(opt)
+	if err != nil {
+		return s, err
+	}
 
-  for k, v := range newValues {
-    origValues[k] = v
-  }
+	for k, v := range newValues {
+		origValues[k] = v
+	}
 
-  origURL.RawQuery = origValues.Encode()
-  return origURL.String(), nil
+	origURL.RawQuery = origValues.Encode()
+	return origURL.String(), nil
 }
 
-
 type ApigeeClientOptions struct {
-  httpClient *http.Client;
+	httpClient *http.Client
 
-  // Optional. The Admin base URL. For example, if using OPDK this might be
-  // http://192.168.10.56:8080 . It defaults to https://api.enterprise.apigee.com
-  MgmtUrl string
+	// Optional. The Admin base URL. For example, if using OPDK this might be
+	// http://192.168.10.56:8080 . It defaults to https://api.enterprise.apigee.com
+	MgmtUrl string
 
-  // Specify the Edge organization name.
-  Org string;
+	// Specify the Edge organization name.
+	Org string
 
-  // Required. Authentication information for the Edge Management server.
-  Auth *AdminAuth
+	// Required. Authentication information for the Edge Management server.
+	Auth *AdminAuth
 
-  // Optional. Warning: if set to true, HTTP Basic Auth base64 blobs will appear in output.
-  Debug bool
+	// Optional. Warning: if set to true, HTTP Basic Auth base64 blobs will appear in output.
+	Debug bool
 }
 
 // AdminAuth holds information about how to authenticate to the Edge Management server.
 type AdminAuth struct {
-  // Optional. The path to the .netrc file that holds credentials for the Edge Management server.
-  // By default, this is ${HOME}/.netrc .  If you specify a Password, this option is ignored.
-  NetrcPath string
+	// Optional. The path to the .netrc file that holds credentials for the Edge Management server.
+	// By default, this is ${HOME}/.netrc .  If you specify a Password, this option is ignored.
+	NetrcPath string
 
-  // Optional. The username to use when authenticating to the Edge Management server.
-  // Ignored if you specify a NetrcPath.
-  Username string
+	// Optional. The username to use when authenticating to the Edge Management server.
+	// Ignored if you specify a NetrcPath.
+	Username string
 
-  // Optional. Used if you explicitly specify a Password.
-  Password string
+	// Optional. Used if you explicitly specify a Password.
+	Password string
 }
 
-
 func retrieveAuthFromNetrc(netrcPath, host string) (*AdminAuth, error) {
-  if netrcPath == "" {
-    netrcPath = os.ExpandEnv("${HOME}/.netrc")
-  }
-  n, e := netrc.ParseFile(netrcPath)
-  if e != nil {
-    fmt.Printf("while parsing .netrc, error:\n%#v\n", e)
-    return nil, e
-  }
-  machine := n.FindMachine(host) // eg, "api.enterprise.apigee.com"
-  if machine == nil || machine.Password == "" {
-    msg := fmt.Sprintf("while scanning %s, cannot find machine:%s", netrcPath, host)
-    return nil, errors.New(msg)
-  }
-  auth := &AdminAuth{Username: machine.Login, Password: machine.Password}
-  return auth, nil
+	if netrcPath == "" {
+		netrcPath = os.ExpandEnv("${HOME}/.netrc")
+	}
+	n, e := netrc.ParseFile(netrcPath)
+	if e != nil {
+		fmt.Printf("while parsing .netrc, error:\n%#v\n", e)
+		return nil, e
+	}
+	machine := n.FindMachine(host) // eg, "api.enterprise.apigee.com"
+	if machine == nil || machine.Password == "" {
+		msg := fmt.Sprintf("while scanning %s, cannot find machine:%s", netrcPath, host)
+		return nil, errors.New(msg)
+	}
+	auth := &AdminAuth{Username: machine.Login, Password: machine.Password}
+	return auth, nil
 }
 
 // NewApigeeClient returns a new ApigeeClient.
-func NewApigeeClient(o *ApigeeClientOptions) (*ApigeeClient,error) {
-  httpClient := o.httpClient
-  if o.httpClient == nil {
-    httpClient = http.DefaultClient
-  }
-  mgmtUrl := o.MgmtUrl
-  if o.MgmtUrl == "" {
-    mgmtUrl = defaultBaseURL
-  }
-  baseURL, err := url.Parse(mgmtUrl)
-  if err != nil {
-    return nil, err
-  }
-  baseURL.Path = path.Join(baseURL.Path, "v1/o/", o.Org, "/")
+func NewApigeeClient(o *ApigeeClientOptions) (*ApigeeClient, error) {
+	httpClient := o.httpClient
+	if o.httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	mgmtUrl := o.MgmtUrl
+	if o.MgmtUrl == "" {
+		mgmtUrl = defaultBaseURL
+	}
+	baseURL, err := url.Parse(mgmtUrl)
+	if err != nil {
+		return nil, err
+	}
+	baseURL.Path = path.Join(baseURL.Path, "v1/o/", o.Org, "/")
 
-  c := &ApigeeClient{client: httpClient, BaseURL: baseURL, UserAgent: userAgent}
-  c.SharedFlows = &SharedFlowsServiceOp{client: c}
-  c.Proxies = &ProxiesServiceOp{client: c}
-  c.Products = &ProductsServiceOp{client: c}
-  c.Developers = &DevelopersServiceOp{client: c}
-  c.Environments = &EnvironmentsServiceOp{client: c}
-  c.Organization = &OrganizationServiceOp{client: c}
-  c.Caches = &CachesServiceOp{client: c}
+	c := &ApigeeClient{client: httpClient, BaseURL: baseURL, UserAgent: userAgent}
+	c.SharedFlows = &SharedFlowsServiceOp{client: c}
+	c.Proxies = &ProxiesServiceOp{client: c}
+	c.Products = &ProductsServiceOp{client: c}
+	c.Developers = &DevelopersServiceOp{client: c}
+	c.Environments = &EnvironmentsServiceOp{client: c}
+	c.Organization = &OrganizationServiceOp{client: c}
+	c.Caches = &CachesServiceOp{client: c}
 	c.TargetServers = &TargetserversServiceOp{client: c}
-  c.Options = *o;
+	c.Options = *o
 
-  var e error = nil
-  if o.Auth == nil {
-    c.auth, e = retrieveAuthFromNetrc("", baseURL.Host)
-  } else if o.Auth.Password == "" {
-    c.auth, e = retrieveAuthFromNetrc(o.Auth.NetrcPath, baseURL.Host)
-  } else {
-    c.auth = &AdminAuth{Username: o.Auth.Username, Password: o.Auth.Password}
-  }
+	var e error = nil
+	if o.Auth == nil {
+		c.auth, e = retrieveAuthFromNetrc("", baseURL.Host)
+	} else if o.Auth.Password == "" {
+		c.auth, e = retrieveAuthFromNetrc(o.Auth.NetrcPath, baseURL.Host)
+	} else {
+		c.auth = &AdminAuth{Username: o.Auth.Username, Password: o.Auth.Password}
+	}
 
-  if e != nil {
-    return nil, e
-  }
+	if e != nil {
+		return nil, e
+	}
 
-  if o.Debug {
-    c.debug = true
-    c.onRequestCompleted = func(req *http.Request, resp *http.Response)  {
-      debugDump(httputil.DumpResponse(resp, true))
-    }
-  }
+	if o.Debug {
+		c.debug = true
+		c.onRequestCompleted = func(req *http.Request, resp *http.Response) {
+			debugDump(httputil.DumpResponse(resp, true))
+		}
+	}
 
-  return c, nil
+	return c, nil
 }
-
 
 // // ClientOpt are options for New.
 // type ClientOpt func(*ApigeeClient) error
@@ -270,77 +267,75 @@ func NewApigeeClient(o *ApigeeClientOptions) (*ApigeeClient,error) {
 // always be specified without a preceding slash. If specified, the value
 // pointed to by body is JSON encoded and included in as the request body.
 func (c *ApigeeClient) NewRequest(method, urlStr string, body interface{}) (*http.Request, error) {
-  rel, err := url.Parse(urlStr)
-  ctype := ""
-  if err != nil {
-    return nil, err
-  }
-  //fmt.Printf("BaseURL: %#v\n", c.BaseURL)
-  u := c.BaseURL.ResolveReference(rel)
-  // u, err := url.Parse(c.BaseURL)
-  // if err != nil {
-  //    return nil,err
-  // }
-  //
-  // c.BaseURL = u
-  u.Path = path.Join(c.BaseURL.Path, rel.Path)
+	rel, err := url.Parse(urlStr)
+	ctype := ""
+	if err != nil {
+		return nil, err
+	}
+	//fmt.Printf("BaseURL: %#v\n", c.BaseURL)
+	u := c.BaseURL.ResolveReference(rel)
+	// u, err := url.Parse(c.BaseURL)
+	// if err != nil {
+	//    return nil,err
+	// }
+	//
+	// c.BaseURL = u
+	u.Path = path.Join(c.BaseURL.Path, rel.Path)
 
-  if c.debug {
+	if c.debug {
 		fmt.Printf("u: %#v\n", u)
 	}
 
-  var req *http.Request
-  if body != nil {
-    switch body.(type) {
-      default:
-        ctype = appJson
-        buf := new(bytes.Buffer)
-        err := json.NewEncoder(buf).Encode(body)
-        if err != nil {
-          return nil, err
-        }
-        req, err = http.NewRequest(method, u.String(), buf)
-      case io.Reader:
-        ctype = octetStream
-        req, err = http.NewRequest(method, u.String(), body.(io.Reader))
-    }
-  } else {
-    req, err = http.NewRequest(method, u.String(), nil)
-  }
+	var req *http.Request
+	if body != nil {
+		switch body.(type) {
+		default:
+			ctype = appJson
+			buf := new(bytes.Buffer)
+			err := json.NewEncoder(buf).Encode(body)
+			if err != nil {
+				return nil, err
+			}
+			req, err = http.NewRequest(method, u.String(), buf)
+		case io.Reader:
+			ctype = octetStream
+			req, err = http.NewRequest(method, u.String(), body.(io.Reader))
+		}
+	} else {
+		req, err = http.NewRequest(method, u.String(), nil)
+	}
 
-  if err != nil {
-    return nil, err
-  }
+	if err != nil {
+		return nil, err
+	}
 
-  if ctype != "" {
-    req.Header.Add("Content-Type", ctype)
-  }
-  req.Header.Add("Accept", appJson)
-  req.Header.Add("User-Agent", c.UserAgent)
-  req.SetBasicAuth(c.auth.Username, c.auth.Password)
-  return req, nil
+	if ctype != "" {
+		req.Header.Add("Content-Type", ctype)
+	}
+	req.Header.Add("Accept", appJson)
+	req.Header.Add("User-Agent", c.UserAgent)
+	req.SetBasicAuth(c.auth.Username, c.auth.Password)
+	return req, nil
 }
-
 
 // sets the request completion callback for the API
 func (c *ApigeeClient) OnRequestCompleted(rc RequestCompletionCallback) {
-  c.onRequestCompleted = rc
+	c.onRequestCompleted = rc
 }
 
 // newResponse creates a new Response for the provided http.Response
 func newResponse(r *http.Response) *Response {
-  response := Response{Response: r}
+	response := Response{Response: r}
 
-  return &response
+	return &response
 }
 
-
 func debugDump(data []byte, err error) {
-    if err == nil {
-        fmt.Printf("%s\n\n", data)
-    } else {
-        log.Fatalf("%s\n\n", err)
-    }
+	if err == nil {
+		fmt.Printf("%s\n\n", data)
+	} else {
+		log.Fatalf("%s\n\n", err)
+	}
 }
 
 // Do sends an API request and returns the API response. The API response is
@@ -348,55 +343,55 @@ func debugDump(data []byte, err error) {
 // if an API error has occurred. If v implements the io.Writer interface, the
 // raw response will be written to v, without attempting to decode it.
 func (c *ApigeeClient) Do(req *http.Request, v interface{}) (*Response, error) {
-  if c.debug {
-    debugDump(httputil.DumpRequestOut(req, true))
-  }
+	if c.debug {
+		debugDump(httputil.DumpRequestOut(req, true))
+	}
 
-  resp, e := c.client.Do(req)
-  if e != nil {
-    return nil, e
-  }
-  if c.onRequestCompleted != nil {
-    c.onRequestCompleted(req, resp)
-  }
+	resp, e := c.client.Do(req)
+	if e != nil {
+		return nil, e
+	}
+	if c.onRequestCompleted != nil {
+		c.onRequestCompleted(req, resp)
+	}
 
-  defer func() {
-    if error := resp.Body.Close(); e == nil {
-      e = error
-    }
-  }()
+	defer func() {
+		if error := resp.Body.Close(); e == nil {
+			e = error
+		}
+	}()
 
-  response := newResponse(resp)
+	response := newResponse(resp)
 
-  e = CheckResponse(resp)
-  if e != nil {
-    return response, e
-  }
+	e = CheckResponse(resp)
+	if e != nil {
+		return response, e
+	}
 
-  if v != nil {
-    if w, ok := v.(io.Writer); ok {
-      _, e := io.Copy(w, resp.Body)
-      if e != nil {
-        return nil, e
-      }
-    } else {
-      e := json.NewDecoder(resp.Body).Decode(v)
-      if e != nil {
-        return nil, e
-      }
-    }
-  }
+	if v != nil {
+		if w, ok := v.(io.Writer); ok {
+			_, e := io.Copy(w, resp.Body)
+			if e != nil {
+				return nil, e
+			}
+		} else {
+			e := json.NewDecoder(resp.Body).Decode(v)
+			if e != nil {
+				return nil, e
+			}
+		}
+	}
 
-  return response, e
+	return response, e
 }
 
 func (r *ErrorResponse) Error() string {
-  // if r.RequestID != "" {
-  //   return fmt.Sprintf("%v %v: %d (request %q) %v",
-  //     r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.RequestID, r.Message)
-  // }
-  return fmt.Sprintf("%v %v: %d %v",
-    r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.Message)
+	// if r.RequestID != "" {
+	//   return fmt.Sprintf("%v %v: %d (request %q) %v",
+	//     r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.RequestID, r.Message)
+	// }
+	return fmt.Sprintf("%v %v: %d %v",
+		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.Message)
 }
 
 // CheckResponse checks the API response for errors, and returns them if
@@ -405,51 +400,50 @@ func (r *ErrorResponse) Error() string {
 // body, or a JSON response body that maps to ErrorResponse. Any other response
 // body will be silently ignored.
 func CheckResponse(r *http.Response) error {
-  if c := r.StatusCode; c >= 200 && c <= 299 {
-    return nil
-  }
+	if c := r.StatusCode; c >= 200 && c <= 299 {
+		return nil
+	}
 
-  errorResponse := &ErrorResponse{Response: r}
-  data, err := ioutil.ReadAll(r.Body)
-  if err == nil && len(data) > 0 {
-    err := json.Unmarshal(data, errorResponse)
-    if err != nil {
-      return err
-    }
-  }
+	errorResponse := &ErrorResponse{Response: r}
+	data, err := ioutil.ReadAll(r.Body)
+	if err == nil && len(data) > 0 {
+		err := json.Unmarshal(data, errorResponse)
+		if err != nil {
+			return err
+		}
+	}
 
-  return errorResponse
+	return errorResponse
 }
-
 
 // String is a helper routine that allocates a new string value
 // to store v and returns a pointer to it.
 func String(v string) *string {
-  p := new(string)
-  *p = v
-  return p
+	p := new(string)
+	*p = v
+	return p
 }
 
 // Int is a helper routine that allocates a new int32 value
 // to store v and returns a pointer to it, but unlike Int32
 // its argument value is an int.
 func Int(v int) *int {
-  p := new(int)
-  *p = v
-  return p
+	p := new(int)
+	*p = v
+	return p
 }
 
 // Bool is a helper routine that allocates a new bool value
 // to store v and returns a pointer to it.
 func Bool(v bool) *bool {
-  p := new(bool)
-  *p = v
-  return p
+	p := new(bool)
+	*p = v
+	return p
 }
 
 // StreamToString converts a reader to a string
 func StreamToString(stream io.Reader) string {
-  buf := new(bytes.Buffer)
-  _, _ = buf.ReadFrom(stream)
-  return buf.String()
+	buf := new(bytes.Buffer)
+	_, _ = buf.ReadFrom(stream)
+	return buf.String()
 }

--- a/attributes.go
+++ b/attributes.go
@@ -1,72 +1,71 @@
 package apigee
 
 import (
- // "strconv"
- // "strings"
-  "encoding/json"
-  "sort"
+	// "strconv"
+	// "strings"
+	"encoding/json"
+	"sort"
 )
 
 // Attributes represents a revision number. Edge returns rev numbers in string form.
 // This marshals and unmarshals between that format and int.
 type Attributes map[string]string
 
-
 // This is just a wrapper struct to aid in serialization and de-serialization.
 type PropertyWrapper struct {
-  Property      Attributes  `json:"property,omitempty"`
+	Property Attributes `json:"property,omitempty"`
 }
-
 
 // MarshalJSON implements the json.Marshaler interface. It marshals from
 // an Attributes object (which is really a map[string]string) into a JSON that looks like
 //    [ { "name" : "aaaaaa", "value" : "1234abcd"}, { "name" : "...", "value" : "..."} ]
 func (attrs Attributes) MarshalJSON() ([]byte, error) {
 
-  // According to the Golang spec, iterating over a map is
-  // non-deterministic. This makes a problem for testing. To address that, we
-  // sort the keys. The JSON returned by this fn will thus always be the same.
-  var keys []string
-  for k := range attrs {
-    keys = append(keys, k)
-  }
-  sort.Strings(keys)
+	// According to the Golang spec, iterating over a map is
+	// non-deterministic. This makes a problem for testing. To address that, we
+	// sort the keys. The JSON returned by this fn will thus always be the same.
+	var keys []string
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
 
-  var holder []map[string]string
+	var holder []map[string]string
 
-  // iterate the map according a lexicographic sort of the keys
-  for _, k := range keys {
-    n := map[string]string{}
-    n["name"]=k; n["value"]=attrs[k]
-    holder = append(holder, n)
-  }
-  j,_ := json.Marshal(holder)
+	// iterate the map according a lexicographic sort of the keys
+	for _, k := range keys {
+		n := map[string]string{}
+		n["name"] = k
+		n["value"] = attrs[k]
+		holder = append(holder, n)
+	}
+	j, _ := json.Marshal(holder)
 
-  return j, nil
+	return j, nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface. It unmarshals from
 // a string like "2" (including the quotes), into an integer 2.
 func (attrs *Attributes) UnmarshalJSON(b []byte) error {
-  var maybe []map[string]string
-  e := json.Unmarshal(b, &maybe)
-  if e == nil {
-    //fmt.Printf("UnmarshalJSON: %v\n", maybe)
-    a := Attributes{}
-    for _, v := range maybe {
-      if name, ok := v["name"]; ok {
-        if val, ok := v["value"]; ok {
-          a[name] = val
-        }
-      }
-    }
-    *attrs = a
-  }
-  return nil
+	var maybe []map[string]string
+	e := json.Unmarshal(b, &maybe)
+	if e == nil {
+		//fmt.Printf("UnmarshalJSON: %v\n", maybe)
+		a := Attributes{}
+		for _, v := range maybe {
+			if name, ok := v["name"]; ok {
+				if val, ok := v["value"]; ok {
+					a[name] = val
+				}
+			}
+		}
+		*attrs = a
+	}
+	return nil
 }
 
 func (a Attributes) String() string {
-  //return fmt.Sprintf("%v", string(a))
-  v,_ := json.Marshal(a)
-  return string(v)
+	//return fmt.Sprintf("%v", string(a))
+	v, _ := json.Marshal(a)
+	return string(v)
 }

--- a/attributes_test.go
+++ b/attributes_test.go
@@ -1,24 +1,24 @@
 package apigee
 
 import (
-  "encoding/json"
-  "testing"
-  "bytes"
+	"bytes"
+	"encoding/json"
+	"testing"
 )
 
 const (
-  attrsJson1 = `[ {
+	attrsJson1 = `[ {
     "name" : "access",
     "value" : "private"
   } ]`
-  attrsJson2 = `[ {
+	attrsJson2 = `[ {
     "name" : "access",
     "value" : "private"
   } , {
     "name" : "creator",
     "value" : "Brahma"
   } ]`
-  attrsJson3 = `[ {
+	attrsJson3 = `[ {
     "name" : "access",
     "value" : "private"
   }, {
@@ -31,71 +31,69 @@ const (
 )
 
 var (
-  attrsMap1 = Attributes{"access":"private"}
-  attrsMap2 = Attributes{"access":"private", "creator":"Brahma"}
-  attrsMap3 = Attributes{"access":"private", "creator":"Brahma","lastModified":"Wednesday,  7 September 2016, 14:45"}
+	attrsMap1 = Attributes{"access": "private"}
+	attrsMap2 = Attributes{"access": "private", "creator": "Brahma"}
+	attrsMap3 = Attributes{"access": "private", "creator": "Brahma", "lastModified": "Wednesday,  7 September 2016, 14:45"}
 )
 
 func TestAttributes_Unmarshal(t *testing.T) {
-  testCases := []struct {
-    desc         string
-    data         string
-    expected     Attributes
-    expectError  bool
-    equal        bool
-  }{
-    {"one member   ", attrsJson1, attrsMap1, false, true},
-    {"two members  ", attrsJson2, attrsMap2, false, true},
-    {"three members", attrsJson3, attrsMap3, false, true},
-  }
-  for _, tc := range testCases {
-    var got Attributes
-    err := json.Unmarshal([]byte(tc.data), &got)
-    t.Logf("%s: got=%v", tc.desc, got)
-    if gotErr := err != nil; gotErr != tc.expectError {
-      t.Errorf("%s: gotErr=%v, expectError=%v, err=%v", tc.desc, gotErr, tc.expectError, err)
-      continue
-    }
-    equal := got.String() == tc.expected.String()
-    if equal != tc.equal {
-      t.Errorf("%14s: value[got=%#v, expected=%#v], equal[got=%v, expected=%v]",
-        tc.desc, got, tc.expected, equal, tc.equal)
-    }
-  }
+	testCases := []struct {
+		desc        string
+		data        string
+		expected    Attributes
+		expectError bool
+		equal       bool
+	}{
+		{"one member   ", attrsJson1, attrsMap1, false, true},
+		{"two members  ", attrsJson2, attrsMap2, false, true},
+		{"three members", attrsJson3, attrsMap3, false, true},
+	}
+	for _, tc := range testCases {
+		var got Attributes
+		err := json.Unmarshal([]byte(tc.data), &got)
+		t.Logf("%s: got=%v", tc.desc, got)
+		if gotErr := err != nil; gotErr != tc.expectError {
+			t.Errorf("%s: gotErr=%v, expectError=%v, err=%v", tc.desc, gotErr, tc.expectError, err)
+			continue
+		}
+		equal := got.String() == tc.expected.String()
+		if equal != tc.equal {
+			t.Errorf("%14s: value[got=%#v, expected=%#v], equal[got=%v, expected=%v]",
+				tc.desc, got, tc.expected, equal, tc.equal)
+		}
+	}
 }
-
 
 func TestAttributes_Marshal(t *testing.T) {
-  testCases := []struct {
-    desc         string
-    data         Attributes
-    expected     string
-    expectError  bool
-    equal        bool
-  }{
-    {"case 1 ", attrsMap1, attrsJson1, false, true},
-    {"case 2 ", attrsMap2, attrsJson2, false, true},
-    {"case 3 ", attrsMap3, attrsJson3, false, true},
-  }
-  
-  for _, tc := range testCases {
-    out, err := json.Marshal(tc.data)
-    if gotErr := (err != nil); gotErr != tc.expectError {
-      t.Errorf("%s: gotErr=%v, expectError=%v, err=%v", tc.desc, gotErr, tc.expectError, err)
-    }
-    got := string(out)
-    buffer := new(bytes.Buffer)
-    if err := json.Compact(buffer, []byte(tc.expected)); err != nil {
-      t.Errorf("%s: %v", tc.desc, err)
-    }
-    equal := got == buffer.String() 
-    if equal != tc.equal {
-      t.Errorf("%s: value[actual=%s, expected=%s], equal[actual=%v, expected=%v]",
-        tc.desc, got, tc.expected, equal, tc.equal)
-    }
-  }
-}
+	testCases := []struct {
+		desc        string
+		data        Attributes
+		expected    string
+		expectError bool
+		equal       bool
+	}{
+		{"case 1 ", attrsMap1, attrsJson1, false, true},
+		{"case 2 ", attrsMap2, attrsJson2, false, true},
+		{"case 3 ", attrsMap3, attrsJson3, false, true},
+	}
 
+	for _, tc := range testCases {
+		out, err := json.Marshal(tc.data)
+		if gotErr := (err != nil); gotErr != tc.expectError {
+			t.Errorf("%s: gotErr=%v, expectError=%v, err=%v", tc.desc, gotErr, tc.expectError, err)
+		}
+		got := string(out)
+		buffer := new(bytes.Buffer)
+		if err := json.Compact(buffer, []byte(tc.expected)); err != nil {
+			t.Errorf("%s: %v", tc.desc, err)
+		}
+		equal := got == buffer.String()
+		if equal != tc.equal {
+			t.Errorf("%s: value[actual=%s, expected=%s], equal[actual=%v, expected=%v]",
+				tc.desc, got, tc.expected, equal, tc.equal)
+		}
+	}
+}
 
 // func TestTimstamp_MarshalReflexivity(t *testing.T) {
 //   testCases := []struct {
@@ -120,4 +118,3 @@ func TestAttributes_Marshal(t *testing.T) {
 //     }
 //   }
 // }
-

--- a/cacheexpiry.go
+++ b/cacheexpiry.go
@@ -1,17 +1,17 @@
 package apigee
 
 import (
-  "fmt"
-  "encoding/json"
+	"encoding/json"
+	"fmt"
 )
 
 // CacheExpiry represents the expiry settings on a cache.  This struct marshals
 // and unmarshals between the json format Edge uses and a reasonably clear
 // golang struct.
 type CacheExpiry struct {
-  ExpiryType    string 
-  ExpiryValue   string 
-  ValuesNull    bool
+	ExpiryType  string
+	ExpiryValue string
+	ValuesNull  bool
 }
 
 // serialization format:
@@ -34,13 +34,13 @@ type CacheExpiry struct {
 //     }
 //
 func (ce CacheExpiry) MarshalJSON() ([]byte, error) {
-  valueMap := map[string]string{}
-  valueMap["value"] = ce.ExpiryValue
-  m1 := map[string]interface{}{}
-  m1["valuesNull"] = ce.ValuesNull
-  m1[ce.ExpiryType] = valueMap
-  j,_ := json.Marshal(m1)
-  return []byte(j), nil
+	valueMap := map[string]string{}
+	valueMap["value"] = ce.ExpiryValue
+	m1 := map[string]interface{}{}
+	m1["valuesNull"] = ce.ValuesNull
+	m1[ce.ExpiryType] = valueMap
+	j, _ := json.Marshal(m1)
+	return []byte(j), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface. It unmarshals from
@@ -54,28 +54,28 @@ func (ce CacheExpiry) MarshalJSON() ([]byte, error) {
 // ...into a CacheExpiry struct.
 //
 func (ce *CacheExpiry) UnmarshalJSON(b []byte) error {
-  var m1 map[string]interface{}
-  e := json.Unmarshal(b, &m1)
-  if e == nil {
-    entry := CacheExpiry{}
-    if v, ok := m1["valuesNull"]; ok {
-      entry.ValuesNull = v.(bool)
-    } else {
-      entry.ValuesNull = false
-    }
-    candidates := []string{"expiryDate", "timeOfDay", "timeoutInSec"}
-    for _, k := range candidates {
-      if v, ok := m1[k]; ok {
-        entry.ExpiryType = k
-        
-        entry.ExpiryValue = ((v.(map[string]interface{}))["value"]).(string)
-      }
-    }
-    *ce = entry
-  }
-  return nil
+	var m1 map[string]interface{}
+	e := json.Unmarshal(b, &m1)
+	if e == nil {
+		entry := CacheExpiry{}
+		if v, ok := m1["valuesNull"]; ok {
+			entry.ValuesNull = v.(bool)
+		} else {
+			entry.ValuesNull = false
+		}
+		candidates := []string{"expiryDate", "timeOfDay", "timeoutInSec"}
+		for _, k := range candidates {
+			if v, ok := m1[k]; ok {
+				entry.ExpiryType = k
+
+				entry.ExpiryValue = ((v.(map[string]interface{}))["value"]).(string)
+			}
+		}
+		*ce = entry
+	}
+	return nil
 }
 
 func (ce CacheExpiry) String() string {
-  return fmt.Sprintf("CacheExpiry[%s,%s,%t]", ce.ExpiryType,ce.ExpiryValue, ce.ValuesNull)
+	return fmt.Sprintf("CacheExpiry[%s,%s,%t]", ce.ExpiryType, ce.ExpiryValue, ce.ValuesNull)
 }

--- a/cacheexpiry_test.go
+++ b/cacheexpiry_test.go
@@ -1,96 +1,92 @@
 package apigee
 
 import (
-  "encoding/json"
-  "testing"
-  "bytes"
+	"bytes"
+	"encoding/json"
+	"testing"
 )
 
 const (
-  cacheJson1 = `{
+	cacheJson1 = `{
    "expiryDate": { "value": "09-22-2016" },
    "valuesNull" : false
  }`
 
-  cacheJson2 = `{
+	cacheJson2 = `{
    "timeoutInSec" : { "value" : "300" },
    "valuesNull" : false
  }`
 
-  cacheJson3 = `{
+	cacheJson3 = `{
    "timeOfDay": { "value" : "14:30:00" },
    "valuesNull" : false
  }`
 )
 
-
 var (
-  cacheExpiry1 = CacheExpiry{"expiryDate","09-22-2016",false}
-  cacheExpiry2 = CacheExpiry{"timeoutInSec","300",false}
-  cacheExpiry3 = CacheExpiry{"timeOfDay","14:30:00",false}
+	cacheExpiry1 = CacheExpiry{"expiryDate", "09-22-2016", false}
+	cacheExpiry2 = CacheExpiry{"timeoutInSec", "300", false}
+	cacheExpiry3 = CacheExpiry{"timeOfDay", "14:30:00", false}
 )
 
-
 func TestCacheExpiry_Unmarshal(t *testing.T) {
-  testCases := []struct {
-    desc      string
-    data      string
-    expected  CacheExpiry
-    wantErr   bool
-    equal     bool
-  }{
-    {"cacheJson1", cacheJson1, cacheExpiry1, false, true},
-    {"cacheJson2", cacheJson2, cacheExpiry2, false, true},
-    {"cacheJson3", cacheJson3, cacheExpiry3, false, true},
-  }
-  for _, tc := range testCases {
-    var got CacheExpiry
-    err := json.Unmarshal([]byte(tc.data), &got)
-    t.Logf("%s: got=%v", tc.desc, got)
-    if gotErr := err != nil; gotErr != tc.wantErr {
-      t.Errorf("%s: gotErr=%v, wantErr=%v, err=%v", tc.desc, gotErr, tc.wantErr, err)
-      continue
-    }
-    equal := got.String() == tc.expected.String()
-    if equal != tc.equal {
-      t.Errorf("%14s: value[got=%#v, expected=%#v], equal[got=%v, expected=%v]",
-        tc.desc, got, tc.expected, equal, tc.equal)
-    }
-  }
+	testCases := []struct {
+		desc     string
+		data     string
+		expected CacheExpiry
+		wantErr  bool
+		equal    bool
+	}{
+		{"cacheJson1", cacheJson1, cacheExpiry1, false, true},
+		{"cacheJson2", cacheJson2, cacheExpiry2, false, true},
+		{"cacheJson3", cacheJson3, cacheExpiry3, false, true},
+	}
+	for _, tc := range testCases {
+		var got CacheExpiry
+		err := json.Unmarshal([]byte(tc.data), &got)
+		t.Logf("%s: got=%v", tc.desc, got)
+		if gotErr := err != nil; gotErr != tc.wantErr {
+			t.Errorf("%s: gotErr=%v, wantErr=%v, err=%v", tc.desc, gotErr, tc.wantErr, err)
+			continue
+		}
+		equal := got.String() == tc.expected.String()
+		if equal != tc.equal {
+			t.Errorf("%14s: value[got=%#v, expected=%#v], equal[got=%v, expected=%v]",
+				tc.desc, got, tc.expected, equal, tc.equal)
+		}
+	}
 }
-
 
 func TestCacheExpiry_Marshal(t *testing.T) {
-  testCases := []struct {
-    desc      string
-    data      CacheExpiry
-    expected  string
-    wantErr   bool
-    equal     bool
-  }{
-    {"cacheJson1", cacheExpiry1, cacheJson1, false, true},
-    {"cacheJson2", cacheExpiry2, cacheJson2, false, true},
-    {"cacheJson3", cacheExpiry3, cacheJson3, false, true},
-  }
+	testCases := []struct {
+		desc     string
+		data     CacheExpiry
+		expected string
+		wantErr  bool
+		equal    bool
+	}{
+		{"cacheJson1", cacheExpiry1, cacheJson1, false, true},
+		{"cacheJson2", cacheExpiry2, cacheJson2, false, true},
+		{"cacheJson3", cacheExpiry3, cacheJson3, false, true},
+	}
 
-  for _, tc := range testCases {
-    out, err := json.Marshal(tc.data)
-    if gotErr := (err != nil); gotErr != tc.wantErr {
-      t.Errorf("%s: gotErr=%v, wantErr=%v, err=%v", tc.desc, gotErr, tc.wantErr, err)
-    }
-    got := string(out)
-    buffer := new(bytes.Buffer)
-    if err := json.Compact(buffer, []byte(tc.expected)); err != nil {
-      t.Errorf("%s: %v", tc.desc, err)
-    }
-    equal := got == buffer.String()
-    if equal != tc.equal {
-      t.Errorf("%s: value[actual=%s, expected=%s], equal[actual=%v, expected=%v]",
-        tc.desc, got, tc.expected, equal, tc.equal)
-    }
-  }
+	for _, tc := range testCases {
+		out, err := json.Marshal(tc.data)
+		if gotErr := (err != nil); gotErr != tc.wantErr {
+			t.Errorf("%s: gotErr=%v, wantErr=%v, err=%v", tc.desc, gotErr, tc.wantErr, err)
+		}
+		got := string(out)
+		buffer := new(bytes.Buffer)
+		if err := json.Compact(buffer, []byte(tc.expected)); err != nil {
+			t.Errorf("%s: %v", tc.desc, err)
+		}
+		equal := got == buffer.String()
+		if equal != tc.equal {
+			t.Errorf("%s: value[actual=%s, expected=%s], equal[actual=%v, expected=%v]",
+				tc.desc, got, tc.expected, equal, tc.equal)
+		}
+	}
 }
-
 
 // func TestTimstamp_MarshalReflexivity(t *testing.T) {
 //   testCases := []struct {

--- a/caches.go
+++ b/caches.go
@@ -1,7 +1,7 @@
 package apigee
 
 import (
-  "path"
+	"path"
 )
 
 const cachesPath = "caches"
@@ -9,70 +9,69 @@ const cachesPath = "caches"
 // CachesService is an interface for interfacing with the Apigee Edge Admin API
 // dealing with caches.
 type CachesService interface {
-  List(string) ([]string, *Response, error)
-  Get(string, string) (*Cache, *Response, error)
+	List(string) ([]string, *Response, error)
+	Get(string, string) (*Cache, *Response, error)
 }
 
 type CachesServiceOp struct {
-  client *ApigeeClient
+	client *ApigeeClient
 }
 
 var _ CachesService = &CachesServiceOp{}
 
 // Cache contains information about a cache within an Edge organization.
 type Cache struct {
-  Name                 string   `json:"name,omitempty"`
-  Description          string   `json:"description,omitempty"`
-  OverflowToDisk       bool     `json:"overflowToDisk,omitempty"`
-  Persistent           bool     `json:"persistent,omitempty"`
-  Distributed          bool     `json:"distributed,omitempty"`
-  DiskSizeInMB         int      `json:"diskSizeInMB,omitempty"`
-  InMemorySizeInKB     int      `json:"inMemorySizeInKB,omitempty"`
-  MaxElementsInMemory  int      `json:"maxElementsInMemory,omitempty"`
-  MaxElementsOnDisk    int           `json:"maxElementsOnDisk,omitempty"`
-  Expiry               CacheExpiry   `json:"expirySettings,omitempty"`
+	Name                string      `json:"name,omitempty"`
+	Description         string      `json:"description,omitempty"`
+	OverflowToDisk      bool        `json:"overflowToDisk,omitempty"`
+	Persistent          bool        `json:"persistent,omitempty"`
+	Distributed         bool        `json:"distributed,omitempty"`
+	DiskSizeInMB        int         `json:"diskSizeInMB,omitempty"`
+	InMemorySizeInKB    int         `json:"inMemorySizeInKB,omitempty"`
+	MaxElementsInMemory int         `json:"maxElementsInMemory,omitempty"`
+	MaxElementsOnDisk   int         `json:"maxElementsOnDisk,omitempty"`
+	Expiry              CacheExpiry `json:"expirySettings,omitempty"`
 }
-
 
 // List retrieves the list of cache names for the organization referred by the ApigeeClient,
 // or a set of cache names for a specific environment within an organization.
 func (s *CachesServiceOp) List(env string) ([]string, *Response, error) {
-  var p1 string
-  if env == "" {
-    p1 = cachesPath
-  } else {
-    p1 = path.Join("e", env, cachesPath)
-  }
-  req, e := s.client.NewRequest("GET", p1, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  namelist := make([]string,0)
-  resp, e := s.client.Do(req, &namelist)
-  if e != nil {
-    return nil, resp, e
-  }
-  return namelist, resp, e
+	var p1 string
+	if env == "" {
+		p1 = cachesPath
+	} else {
+		p1 = path.Join("e", env, cachesPath)
+	}
+	req, e := s.client.NewRequest("GET", p1, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	namelist := make([]string, 0)
+	resp, e := s.client.Do(req, &namelist)
+	if e != nil {
+		return nil, resp, e
+	}
+	return namelist, resp, e
 }
 
 // Get retrieves the information about a Cache in an organization, or about a
 // cache in an environment within an organization. This information includes the
 // properties, and the created and last modified details.
 func (s *CachesServiceOp) Get(name, env string) (*Cache, *Response, error) {
-  var p1 string
-  if env == "" {
-    p1 = path.Join(cachesPath, env)
-  } else {
-    p1 = path.Join("e", env, cachesPath)
-  }
-  req, e := s.client.NewRequest("GET", p1, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  returnedCache := Cache{}
-  resp, e := s.client.Do(req, &returnedCache)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &returnedCache, resp, e
+	var p1 string
+	if env == "" {
+		p1 = path.Join(cachesPath, env)
+	} else {
+		p1 = path.Join("e", env, cachesPath)
+	}
+	req, e := s.client.NewRequest("GET", p1, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedCache := Cache{}
+	resp, e := s.client.Do(req, &returnedCache)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedCache, resp, e
 }

--- a/deployable.go
+++ b/deployable.go
@@ -1,61 +1,60 @@
 package apigee
 
 import (
-  "path"
-  "net/url"
-  "fmt"
-  "time"
-  "strings"
-  "archive/zip"
-  "os"
-  "path/filepath"
-  "io"
-  "io/ioutil"
-  "errors"
+	"archive/zip"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
 )
 
 // DeployableAsset contains information about an API Proxy or SharedFlow within an Apigee organization.
 type DeployableAsset struct {
-  Revisions   []Revision    `json:"revision,omitempty"`
-  Name        string        `json:"name,omitempty"`
-  MetaData    DeployableMetadata `json:"metaData,omitempty"`
+	Revisions []Revision         `json:"revision,omitempty"`
+	Name      string             `json:"name,omitempty"`
+	MetaData  DeployableMetadata `json:"metaData,omitempty"`
 }
 
 // DeployableRevision holds information about a revision of an API Proxy, or a SharedFlow.
 type DeployableRevision struct {
-  Name            string     `json:"name,omitempty"`
-  DisplayName     string     `json:"displayName,omitempty"`
-  Revision        Revision   `json:"revision,omitempty"`
-  CreatedBy       string     `json:"createdBy,omitempty"`
-  CreatedAt       Timestamp  `json:"createdAt,omitempty"`
-  LastModifiedBy  string     `json:"lastModifiedBy,omitempty"`
-  LastModifiedAt  Timestamp  `json:"lastModifiedAt,omitempty"`
-  Description     string     `json:"description,omitempty"`
-  ContextInfo     string     `json:"contextInfo,omitempty"`
-  TargetEndpoints []string   `json:"targetEndpoints,omitempty"`
-  TargetServers   []string   `json:"targetServers,omitempty"`
-  Resources       []string   `json:"resources,omitempty"`
-  ProxyEndpoints  []string   `json:"proxyEndpoints,omitempty"`
-  SharedFlows     []string   `json:"sharedFlows,omitempty"`
-  Policies        []string   `json:"policies,omitempty"`
-  Type            string     `json:"type,omitempty"`
+	Name            string    `json:"name,omitempty"`
+	DisplayName     string    `json:"displayName,omitempty"`
+	Revision        Revision  `json:"revision,omitempty"`
+	CreatedBy       string    `json:"createdBy,omitempty"`
+	CreatedAt       Timestamp `json:"createdAt,omitempty"`
+	LastModifiedBy  string    `json:"lastModifiedBy,omitempty"`
+	LastModifiedAt  Timestamp `json:"lastModifiedAt,omitempty"`
+	Description     string    `json:"description,omitempty"`
+	ContextInfo     string    `json:"contextInfo,omitempty"`
+	TargetEndpoints []string  `json:"targetEndpoints,omitempty"`
+	TargetServers   []string  `json:"targetServers,omitempty"`
+	Resources       []string  `json:"resources,omitempty"`
+	ProxyEndpoints  []string  `json:"proxyEndpoints,omitempty"`
+	SharedFlows     []string  `json:"sharedFlows,omitempty"`
+	Policies        []string  `json:"policies,omitempty"`
+	Type            string    `json:"type,omitempty"`
 }
 
 // ProxyMetadata contains information related to the creation and last modified
 // time and actor for an API Proxy within an organization.
 type DeployableMetadata struct {
-  LastModifiedBy  string     `json:"lastModifiedBy,omitempty"`
-  CreatedBy       string     `json:"createdBy,omitempty"`
-  LastModifiedAt  Timestamp  `json:"lastModifiedAt,omitempty"`
-  CreatedAt       Timestamp  `json:"createdAt,omitempty"`
+	LastModifiedBy string    `json:"lastModifiedBy,omitempty"`
+	CreatedBy      string    `json:"createdBy,omitempty"`
+	LastModifiedAt Timestamp `json:"lastModifiedAt,omitempty"`
+	CreatedAt      Timestamp `json:"createdAt,omitempty"`
 }
 
 // When Delete returns successfully, it returns a payload that contains very little useful
 // information. This struct deserializes that information.
 type DeletedItemInfo struct {
-  Name   string   `json:"name,omitempty"`
+	Name string `json:"name,omitempty"`
 }
-
 
 // When inquiring the deployment status of an API PRoxy revision, even implicitly
 // as when performing a Deploy or Undeploy, the response includes the deployment
@@ -66,164 +65,163 @@ type DeletedItemInfo struct {
 // experiencing a problem and cannot undeploy, or more commonly, cannot deploy an
 // API Proxy, this struct will hold relevant information.
 type ApigeeServer struct {
-  Status          string        `json:"status,omitempty"`
-  Uuid            string        `json:"uUID,omitempty"`
-  Type            []string      `json:"type,omitempty"`
+	Status string   `json:"status,omitempty"`
+	Uuid   string   `json:"uUID,omitempty"`
+	Type   []string `json:"type,omitempty"`
 }
 
 // Deployment (nee ProxyDeployment) holds information about the deployment state of a
 // all revisions of an API Proxy or SharedFlow.
 type Deployment struct {
-  Environments    []EnvironmentDeployment   `json:"environment,omitempty"`
-  Name            string                    `json:"name,omitempty"`
-  Organization    string                    `json:"organization,omitempty"`
+	Environments []EnvironmentDeployment `json:"environment,omitempty"`
+	Name         string                  `json:"name,omitempty"`
+	Organization string                  `json:"organization,omitempty"`
 }
 
 type EnvironmentDeployment struct {
-  Name            string                `json:"name,omitempty"`
-  Revision        []RevisionDeployment  `json:"revision,omitempty"`
+	Name     string               `json:"name,omitempty"`
+	Revision []RevisionDeployment `json:"revision,omitempty"`
 }
 
 type RevisionDeployment struct {
-  Number        Revision      `json:"name,omitempty"`
-  State         string        `json:"state,omitempty"`
-  Servers       []ApigeeServer  `json:"server,omitempty"`
+	Number  Revision       `json:"name,omitempty"`
+	State   string         `json:"state,omitempty"`
+	Servers []ApigeeServer `json:"server,omitempty"`
 }
 
-
-type Deployable struct { }
+type Deployable struct{}
 
 func (s *Deployable) List(client *ApigeeClient, uriPathElement string) ([]string, *Response, error) {
-  req, e := client.NewRequest("GET", uriPathElement, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  namelist := make([]string,0)
-  resp, e := client.Do(req, &namelist)
-  if e != nil {
-    return nil, resp, e
-  }
-  return namelist, resp, e
+	req, e := client.NewRequest("GET", uriPathElement, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	namelist := make([]string, 0)
+	resp, e := client.Do(req, &namelist)
+	if e != nil {
+		return nil, resp, e
+	}
+	return namelist, resp, e
 }
 
 func (s *Deployable) Get(client *ApigeeClient, uriPathElement, assetName string) (*DeployableAsset, *Response, error) {
-  path := path.Join(uriPathElement, assetName)
-  req, e := client.NewRequest("GET", path, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  returnedAsset := DeployableAsset{}
-  resp, e := client.Do(req, &returnedAsset)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &returnedAsset, resp, e
+	path := path.Join(uriPathElement, assetName)
+	req, e := client.NewRequest("GET", path, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedAsset := DeployableAsset{}
+	resp, e := client.Do(req, &returnedAsset)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedAsset, resp, e
 }
 
 func smartFilter(path string) bool {
-  if strings.HasSuffix(path, "~") {
-    return false
-  }
-  if strings.HasSuffix(path, "#") && strings.HasPrefix(path, "#") {
-    return false
-  }
-  return true
+	if strings.HasSuffix(path, "~") {
+		return false
+	}
+	if strings.HasSuffix(path, "#") && strings.HasPrefix(path, "#") {
+		return false
+	}
+	return true
 }
 
-func zipDirectory (source string, target string, filter func(string) bool) error {
-  zipfile, err := os.Create(target)
-  if err != nil {
-    return err
-  }
-  defer zipfile.Close()
+func zipDirectory(source string, target string, filter func(string) bool) error {
+	zipfile, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+	defer zipfile.Close()
 
-  archive := zip.NewWriter(zipfile)
-  defer archive.Close()
+	archive := zip.NewWriter(zipfile)
+	defer archive.Close()
 
-  info, err := os.Stat(source)
-  if err != nil {
-    return nil
-  }
+	info, err := os.Stat(source)
+	if err != nil {
+		return nil
+	}
 
-  var baseDir string
-  if info.IsDir() {
-    baseDir = filepath.Base(source)
-  }
+	var baseDir string
+	if info.IsDir() {
+		baseDir = filepath.Base(source)
+	}
 
-  filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
-    if filter == nil || filter(path) {
-      if err != nil {
-        return err
-      }
+	filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
+		if filter == nil || filter(path) {
+			if err != nil {
+				return err
+			}
 
-      header, err := zip.FileInfoHeader(info)
-      if err != nil {
-        return err
-      }
+			header, err := zip.FileInfoHeader(info)
+			if err != nil {
+				return err
+			}
 
-      if baseDir != "" {
-        header.Name = filepath.Join(baseDir, strings.TrimPrefix(path, source))
-      }
+			if baseDir != "" {
+				header.Name = filepath.Join(baseDir, strings.TrimPrefix(path, source))
+			}
 
-      // This archive will be unzipped by a Java process.  When ZIP64 extensions
-      // are used, Java insists on having Deflate as the compression method (0x08)
-      // even for directories.
-      header.Method = zip.Deflate
+			// This archive will be unzipped by a Java process.  When ZIP64 extensions
+			// are used, Java insists on having Deflate as the compression method (0x08)
+			// even for directories.
+			header.Method = zip.Deflate
 
-      if info.IsDir() {
-        header.Name += "/"
-      }
+			if info.IsDir() {
+				header.Name += "/"
+			}
 
-      writer, err := archive.CreateHeader(header)
-      if err != nil {
-        return err
-      }
+			writer, err := archive.CreateHeader(header)
+			if err != nil {
+				return err
+			}
 
-      if info.IsDir() {
-        return nil
-      }
+			if info.IsDir() {
+				return nil
+			}
 
-      file, err := os.Open(path)
-      if err != nil {
-        return err
-      }
-      defer file.Close()
-      _, err = io.Copy(writer, file)
-    }
-    return err
-  })
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+			_, err = io.Copy(writer, file)
+		}
+		return err
+	})
 
-  return err
+	return err
 }
 
 func (s *Deployable) Import(client *ApigeeClient, uriPathElement, assetName, source string) (*DeployableRevision, *Response, error) {
-  info, err := os.Stat(source)
-  if err != nil {
-    return nil, nil, err
-  }
-  zipfileName := source
-  if info.IsDir() {
-    // create a temporary zip file
-    if assetName == "" {
-      assetName = filepath.Base(source)
-    }
-    tempDir, e := ioutil.TempDir("", "go-apigee-")
-    if e != nil {
-      return nil, nil, errors.New(fmt.Sprintf("while creating temp dir, error: %#v", e))
-    }
-    zipfileName = path.Join(tempDir, "bundle.zip")
-		var filePathElement string;
+	info, err := os.Stat(source)
+	if err != nil {
+		return nil, nil, err
+	}
+	zipfileName := source
+	if info.IsDir() {
+		// create a temporary zip file
+		if assetName == "" {
+			assetName = filepath.Base(source)
+		}
+		tempDir, e := ioutil.TempDir("", "go-apigee-")
+		if e != nil {
+			return nil, nil, errors.New(fmt.Sprintf("while creating temp dir, error: %#v", e))
+		}
+		zipfileName = path.Join(tempDir, "bundle.zip")
+		var filePathElement string
 		if uriPathElement == "apis" {
 			filePathElement = "apiproxy"
 		} else {
 			filePathElement = "sharedflowbundle"
 		}
 
-    e = zipDirectory (path.Join(source, filePathElement), zipfileName, smartFilter)
-    if e != nil {
-      return nil, nil, errors.New(fmt.Sprintf("while creating temp dir, error: %#v", e))
-    }
-    fmt.Printf("zipped %s into %s\n\n", source, zipfileName)
+		e = zipDirectory(path.Join(source, filePathElement), zipfileName, smartFilter)
+		if e != nil {
+			return nil, nil, errors.New(fmt.Sprintf("while creating temp dir, error: %#v", e))
+		}
+		fmt.Printf("zipped %s into %s\n\n", source, zipfileName)
 		cleanup := func(filename string) {
 			_ = os.Remove(filename)
 			// if e != nil {
@@ -231,195 +229,192 @@ func (s *Deployable) Import(client *ApigeeClient, uriPathElement, assetName, sou
 			// }
 		}
 		defer cleanup(zipfileName)
-  }
+	}
 
-  if !strings.HasSuffix(zipfileName, ".zip") {
-    return nil, nil, errors.New("source must be a zipfile")
-  }
+	if !strings.HasSuffix(zipfileName, ".zip") {
+		return nil, nil, errors.New("source must be a zipfile")
+	}
 
-  info, err = os.Stat(zipfileName)
-  if err != nil {
-    return nil, nil, err
-  }
+	info, err = os.Stat(zipfileName)
+	if err != nil {
+		return nil, nil, err
+	}
 
-  // append the query params
-  origURL, err := url.Parse(uriPathElement)
-  if err != nil {
-     return nil, nil, err
-  }
-  q := origURL.Query()
-  q.Add("action", "import")
-  q.Add("name", assetName)
-  origURL.RawQuery = q.Encode()
-  path := origURL.String()
+	// append the query params
+	origURL, err := url.Parse(uriPathElement)
+	if err != nil {
+		return nil, nil, err
+	}
+	q := origURL.Query()
+	q.Add("action", "import")
+	q.Add("name", assetName)
+	origURL.RawQuery = q.Encode()
+	path := origURL.String()
 
-  ioreader, err := os.Open(zipfileName)
-  if err != nil {
-     return nil, nil, err
-  }
-  defer ioreader.Close()
+	ioreader, err := os.Open(zipfileName)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer ioreader.Close()
 
-  req, e := client.NewRequest("POST", path, ioreader)
-  if e != nil {
-    return nil, nil, e
-  }
-  returnedRevision := DeployableRevision{}
-  resp, e := client.Do(req, &returnedRevision)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &returnedRevision, resp, e
+	req, e := client.NewRequest("POST", path, ioreader)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedRevision := DeployableRevision{}
+	resp, e := client.Do(req, &returnedRevision)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedRevision, resp, e
 }
 
 func (s *Deployable) Export(client *ApigeeClient, uriPathElement, assetName string, rev Revision) (string, *Response, error) {
-  // curl -u USER:PASSWORD \
-  //  http://MGMTSERVER/v1/o/ORGNAME/apis/APINAME/revisions/REVNUMBER?format=bundle > bundle.zip
+	// curl -u USER:PASSWORD \
+	//  http://MGMTSERVER/v1/o/ORGNAME/apis/APINAME/revisions/REVNUMBER?format=bundle > bundle.zip
 
-  path := path.Join(uriPathElement, assetName, "revisions", fmt.Sprintf("%d",rev))
+	path := path.Join(uriPathElement, assetName, "revisions", fmt.Sprintf("%d", rev))
 	// TODO: factor out method: appendQueryParams
-  // append the required query param
-  origURL, err := url.Parse(path)
-  if err != nil {
+	// append the required query param
+	origURL, err := url.Parse(path)
+	if err != nil {
 		return "", nil, err
-  }
-  q := origURL.Query()
-  q.Add("format", "bundle")
-  origURL.RawQuery = q.Encode()
-  path = origURL.String()
+	}
+	q := origURL.Query()
+	q.Add("format", "bundle")
+	origURL.RawQuery = q.Encode()
+	path = origURL.String()
 
-  req, e := client.NewRequest("GET", path, nil)
-  if e != nil {
-    return "", nil, e
-  }
-  req.Header.Del("Accept")
+	req, e := client.NewRequest("GET", path, nil)
+	if e != nil {
+		return "", nil, e
+	}
+	req.Header.Del("Accept")
 
-	var assetType string;
+	var assetType string
 	if uriPathElement == "apis" {
 		assetType = "apiproxy"
 	} else {
 		assetType = "sharedflowbundle"
 	}
 
-  t := time.Now()
-  filename := fmt.Sprintf("%s-%s-r%d-%d%02d%02d-%02d%02d%02d.zip",
+	t := time.Now()
+	filename := fmt.Sprintf("%s-%s-r%d-%d%02d%02d-%02d%02d%02d.zip",
 		assetType, assetName,
-    rev, t.Year(), t.Month(), t.Day(),
-    t.Hour(), t.Minute(), t.Second())
+		rev, t.Year(), t.Month(), t.Day(),
+		t.Hour(), t.Minute(), t.Second())
 
-  out, e := os.Create(filename)
-  if e != nil {
-    return "", nil, e
-  }
+	out, e := os.Create(filename)
+	if e != nil {
+		return "", nil, e
+	}
 
-  resp, e := client.Do(req, out)
-  if e != nil {
-    return "", resp, e
-  }
-  out.Close()
-  return filename, resp, e
+	resp, e := client.Do(req, out)
+	if e != nil {
+		return "", resp, e
+	}
+	out.Close()
+	return filename, resp, e
 }
 
 func (s *Deployable) DeleteRevision(client *ApigeeClient, uriPathElement, assetName string, rev Revision) (*DeployableRevision, *Response, error) {
-  path := path.Join(uriPathElement, assetName, "revisions", fmt.Sprintf("%d",rev))
-  req, e := client.NewRequest("DELETE", path, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  proxyRev := DeployableRevision{}
-  resp, e := client.Do(req, &proxyRev)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &proxyRev, resp, e
+	path := path.Join(uriPathElement, assetName, "revisions", fmt.Sprintf("%d", rev))
+	req, e := client.NewRequest("DELETE", path, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	proxyRev := DeployableRevision{}
+	resp, e := client.Do(req, &proxyRev)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &proxyRev, resp, e
 }
-
 
 func (s *Deployable) Undeploy(client *ApigeeClient, uriPathElement, assetName, env string, rev Revision) (*RevisionDeployment, *Response, error) {
-  path := path.Join(uriPathElement, assetName, "revisions", fmt.Sprintf("%d",rev), "deployments")
-  // append the query params
-  origURL, err := url.Parse(path)
-  if err != nil {
-     return nil, nil, err
-  }
-  q := origURL.Query()
-  q.Add("action", "undeploy")
-  q.Add("env", env)
-  origURL.RawQuery = q.Encode()
-  path = origURL.String()
+	path := path.Join(uriPathElement, assetName, "revisions", fmt.Sprintf("%d", rev), "deployments")
+	// append the query params
+	origURL, err := url.Parse(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	q := origURL.Query()
+	q.Add("action", "undeploy")
+	q.Add("env", env)
+	origURL.RawQuery = q.Encode()
+	path = origURL.String()
 
-  req, e := client.NewRequest("POST", path, nil)
-  if e != nil {
-    return nil, nil, e
-  }
+	req, e := client.NewRequest("POST", path, nil)
+	if e != nil {
+		return nil, nil, e
+	}
 
-  deployment := RevisionDeployment{}
-  resp, e := client.Do(req, &deployment)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &deployment, resp, e
+	deployment := RevisionDeployment{}
+	resp, e := client.Do(req, &deployment)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &deployment, resp, e
 }
-
 
 func (s *Deployable) Deploy(client *ApigeeClient, uriPathElement, assetName, basepath, env string, rev Revision) (*RevisionDeployment, *Response, error) {
-  path := path.Join(uriPathElement, assetName, "revisions", fmt.Sprintf("%d",rev), "deployments")
-  // append the query params
-  origURL, err := url.Parse(path)
-  if err != nil {
-     return nil, nil, err
-  }
-  q := origURL.Query()
-  q.Add("action", "deploy")
-  q.Add("override", "true")
-  q.Add("delay", DeploymentDelay)
-  q.Add("env", env)
-  if basepath != "" {
+	path := path.Join(uriPathElement, assetName, "revisions", fmt.Sprintf("%d", rev), "deployments")
+	// append the query params
+	origURL, err := url.Parse(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	q := origURL.Query()
+	q.Add("action", "deploy")
+	q.Add("override", "true")
+	q.Add("delay", DeploymentDelay)
+	q.Add("env", env)
+	if basepath != "" {
 		q.Add("basepath", basepath)
 	}
-  origURL.RawQuery = q.Encode()
-  path = origURL.String()
+	origURL.RawQuery = q.Encode()
+	path = origURL.String()
 
-  req, e := client.NewRequest("POST", path, nil)
-  if e != nil {
-    return nil, nil, e
-  }
+	req, e := client.NewRequest("POST", path, nil)
+	if e != nil {
+		return nil, nil, e
+	}
 
-  deployment := RevisionDeployment{}
-  resp, e := client.Do(req, &deployment)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &deployment, resp, e
+	deployment := RevisionDeployment{}
+	resp, e := client.Do(req, &deployment)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &deployment, resp, e
 }
-
 
 // Delete an API Proxy and all its revisions from an organization. This method
 // will fail if any of the revisions of the named API Proxy are currently deployed
 // in any environment.
 func (s *Deployable) Delete(client *ApigeeClient, uriPathElement, assetName string) (*DeletedItemInfo, *Response, error) {
-  path := path.Join(uriPathElement, assetName)
-  req, e := client.NewRequest("DELETE", path, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  item := DeletedItemInfo{}
-  resp, e := client.Do(req, &item)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &item, resp, e
+	path := path.Join(uriPathElement, assetName)
+	req, e := client.NewRequest("DELETE", path, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	item := DeletedItemInfo{}
+	resp, e := client.Do(req, &item)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &item, resp, e
 }
 
 func (s *Deployable) GetDeployments(client *ApigeeClient, uriPathElement, assetName string) (*Deployment, *Response, error) {
-  path := path.Join(uriPathElement, assetName, "deployments")
-  req, e := client.NewRequest("GET", path, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  deployments := Deployment{}
-  resp, e := client.Do(req, &deployments)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &deployments, resp, e
+	path := path.Join(uriPathElement, assetName, "deployments")
+	req, e := client.NewRequest("GET", path, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	deployments := Deployment{}
+	resp, e := client.Do(req, &deployments)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &deployments, resp, e
 }

--- a/developerapps.go
+++ b/developerapps.go
@@ -1,98 +1,96 @@
 package apigee
 
 import (
-  "path"
-  "net/url"
-  "errors"
+	"errors"
+	"net/url"
+	"path"
 )
-
 
 // DeveloperAppsService is an interface for interfacing with the Apigee Edge Admin API
 // dealing with apps that belong to a particular developer.
 type DeveloperAppsService interface {
-  Create(DeveloperApp) (*DeveloperApp, *Response, error)
-  Delete(string) (*DeveloperApp, *Response, error)
-  Revoke(string) (*Response, error)
-  Approve(string) (*Response, error)
-  List() ([]string, *Response, error)
-  Get( string) (*DeveloperApp, *Response, error)
-  Update(DeveloperApp) (*DeveloperApp, *Response, error)
+	Create(DeveloperApp) (*DeveloperApp, *Response, error)
+	Delete(string) (*DeveloperApp, *Response, error)
+	Revoke(string) (*Response, error)
+	Approve(string) (*Response, error)
+	List() ([]string, *Response, error)
+	Get(string) (*DeveloperApp, *Response, error)
+	Update(DeveloperApp) (*DeveloperApp, *Response, error)
 }
 
 type DeveloperAppsServiceOp struct {
-  client *ApigeeClient
-  developerId string
+	client      *ApigeeClient
+	developerId string
 }
 
 var _ DeveloperAppsService = &DeveloperAppsServiceOp{}
 
 // DeveloperApp holds information about a registered DeveloperApp.
 type DeveloperApp struct {
-  Name             string      `json:"name,omitempty"`
-  ApiProducts      []string    `json:"apiProducts,omitempty"`
-  InitialKeyExpiry string      `json:"keyExpiresIn,omitempty"`
-  Attributes       Attributes  `json:"attributes,omitempty"`
-  Id               string      `json:"appId,omitempty"`
-  DeveloperId      string      `json:"developerId,omitempty"`
-  Scopes           []string    `json:"scopes,omitempty"`
-  Status           string      `json:"status,omitempty"`
+	Name             string     `json:"name,omitempty"`
+	ApiProducts      []string   `json:"apiProducts,omitempty"`
+	InitialKeyExpiry string     `json:"keyExpiresIn,omitempty"`
+	Attributes       Attributes `json:"attributes,omitempty"`
+	Id               string     `json:"appId,omitempty"`
+	DeveloperId      string     `json:"developerId,omitempty"`
+	Scopes           []string   `json:"scopes,omitempty"`
+	Status           string     `json:"status,omitempty"`
 }
 
 func (s *DeveloperAppsServiceOp) Create(app DeveloperApp) (*DeveloperApp, *Response, error) {
-	if (app.Name == "") {
+	if app.Name == "" {
 		return nil, nil, errors.New("cannot create a developerapp with no name")
 	}
 	appsPath := path.Join(developersPath, s.developerId, "apps")
-  req, e := s.client.NewRequest("POST", appsPath, app)
-  if e != nil {
-    return nil, nil, e
-  }
-  returnedApp := DeveloperApp{}
-  resp, e := s.client.Do(req, &returnedApp)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &returnedApp, resp, e
+	req, e := s.client.NewRequest("POST", appsPath, app)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedApp := DeveloperApp{}
+	resp, e := s.client.Do(req, &returnedApp)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedApp, resp, e
 }
 
 func (s *DeveloperAppsServiceOp) Delete(appName string) (*DeveloperApp, *Response, error) {
-  path := path.Join(developersPath, s.developerId, "apps", appName)
-  req, e := s.client.NewRequest("DELETE", path, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  deletedApp := DeveloperApp{}
-  resp, e := s.client.Do(req, &deletedApp)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &deletedApp, resp, e
+	path := path.Join(developersPath, s.developerId, "apps", appName)
+	req, e := s.client.NewRequest("DELETE", path, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	deletedApp := DeveloperApp{}
+	resp, e := s.client.Do(req, &deletedApp)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &deletedApp, resp, e
 }
 
+func updateAppStatus(s DeveloperAppsServiceOp, appName string, desiredStatus string) (*Response, error) {
 
-func updateAppStatus (s DeveloperAppsServiceOp, appName string, desiredStatus string) (*Response, error) {
+	appPath := path.Join(developersPath, s.developerId, "apps", appName)
 
-  appPath := path.Join(developersPath, s.developerId, "apps", appName)
-
-  // append the necessary query param
-  origURL, e := url.Parse(appPath)
-  if e != nil {
-     return nil, e
-  }
-  q := origURL.Query()
-  q.Add("action", desiredStatus)
-  origURL.RawQuery = q.Encode()
-  appPath = origURL.String()
+	// append the necessary query param
+	origURL, e := url.Parse(appPath)
+	if e != nil {
+		return nil, e
+	}
+	q := origURL.Query()
+	q.Add("action", desiredStatus)
+	origURL.RawQuery = q.Encode()
+	appPath = origURL.String()
 
 	req, e := s.client.NewRequest("POST", appPath, nil)
-  if e != nil {
-    return nil, e
-  }
-  resp, e := s.client.Do(req, nil)
-  if e != nil {
-    return resp, e
-  }
-  return resp, e
+	if e != nil {
+		return nil, e
+	}
+	resp, e := s.client.Do(req, nil)
+	if e != nil {
+		return resp, e
+	}
+	return resp, e
 }
 
 func (s *DeveloperAppsServiceOp) Revoke(appName string) (*Response, error) {
@@ -104,47 +102,47 @@ func (s *DeveloperAppsServiceOp) Approve(appName string) (*Response, error) {
 }
 
 func (s *DeveloperAppsServiceOp) List() ([]string, *Response, error) {
-  appsPath := path.Join(developersPath, s.developerId, "apps")
-  req, e := s.client.NewRequest("GET", appsPath, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  namelist := make([]string,0)
-  resp, e := s.client.Do(req, &namelist)
-  if e != nil {
-    return nil, resp, e
-  }
-  return namelist, resp, e
+	appsPath := path.Join(developersPath, s.developerId, "apps")
+	req, e := s.client.NewRequest("GET", appsPath, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	namelist := make([]string, 0)
+	resp, e := s.client.Do(req, &namelist)
+	if e != nil {
+		return nil, resp, e
+	}
+	return namelist, resp, e
 }
 
 func (s *DeveloperAppsServiceOp) Get(appName string) (*DeveloperApp, *Response, error) {
-  appPath := path.Join(developersPath, s.developerId, "apps", appName)
-  req, e := s.client.NewRequest("GET", appPath, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  returnedApp := DeveloperApp{}
-  resp, e := s.client.Do(req, &returnedApp)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &returnedApp, resp, e
+	appPath := path.Join(developersPath, s.developerId, "apps", appName)
+	req, e := s.client.NewRequest("GET", appPath, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedApp := DeveloperApp{}
+	resp, e := s.client.Do(req, &returnedApp)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedApp, resp, e
 }
 
 func (s *DeveloperAppsServiceOp) Update(app DeveloperApp) (*DeveloperApp, *Response, error) {
 	if app.Name == "" {
-    return nil, nil, errors.New("missing the Name of the App to update")
+		return nil, nil, errors.New("missing the Name of the App to update")
 	}
 	appPath := path.Join(developersPath, s.developerId, "apps", app.Name)
 
-  req, e := s.client.NewRequest("POST", appPath, app)
-  if e != nil {
-    return nil, nil, e
-  }
-  returnedApp := DeveloperApp{}
-  resp, e := s.client.Do(req, &returnedApp)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &returnedApp, resp, e
+	req, e := s.client.NewRequest("POST", appPath, app)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedApp := DeveloperApp{}
+	resp, e := s.client.Do(req, &returnedApp)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedApp, resp, e
 }

--- a/developerapps_test.go
+++ b/developerapps_test.go
@@ -1,8 +1,8 @@
 package apigee
 
 import (
-  "encoding/json"
-  "testing"
+	"encoding/json"
+	"testing"
 )
 
 const (
@@ -28,15 +28,14 @@ func randomAppFromTemplate() (DeveloperApp, error) {
 	return got, e
 }
 
-
 func TestDeveloperAppCreateDelete(t *testing.T) {
-  client := NewClientForTesting(t)
+	client := NewClientForTesting(t)
 	dev, e := randomDeveloperFromTemplate()
-  createdDeveloper, resp, e := client.Developers.Create(dev)
-  if e != nil {
+	createdDeveloper, resp, e := client.Developers.Create(dev)
+	if e != nil {
 		t.Errorf("while creating Edge developer, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	t.Logf("Create: got=%+v", createdDeveloper)
 	t.Logf("resp: got=%+v", resp)
 
@@ -51,70 +50,70 @@ func TestDeveloperAppCreateDelete(t *testing.T) {
 	}
 
 	defer teardown(t)
-  wait(1)
+	wait(1)
 
 	devapps := client.Developers.Apps(createdDeveloper.Email)
 	devapp, e := randomAppFromTemplate()
 
-  createdApp, resp, e := devapps.Create(devapp)
-  if e != nil {
+	createdApp, resp, e := devapps.Create(devapp)
+	if e != nil {
 		t.Errorf("while creating developer app, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	t.Logf("CreateApp: got=%v", createdApp)
 
-  wait(1)
+	wait(1)
 
-  resp, e = devapps.Revoke(createdApp.Name)
-  if e != nil {
+	resp, e = devapps.Revoke(createdApp.Name)
+	if e != nil {
 		t.Errorf("while revoking developer app, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	t.Logf("RevokeApp")
 	wait(1)
 
-  got, resp, e := devapps.Get(createdApp.Name)
-  if e != nil {
+	got, resp, e := devapps.Get(createdApp.Name)
+	if e != nil {
 		t.Errorf("while getting developer app, error:\n%#v\n", e)
-    return
-  }
-	if (got.Name != createdApp.Name) {
+		return
+	}
+	if got.Name != createdApp.Name {
 		t.Errorf("inconsistent name")
 	}
-	if (got.Status != "revoked") {
+	if got.Status != "revoked" {
 		t.Errorf("inconsistent status")
 	}
 	t.Logf("GetApp")
 
-  resp, e = devapps.Approve(createdApp.Name)
-  if e != nil {
+	resp, e = devapps.Approve(createdApp.Name)
+	if e != nil {
 		t.Errorf("while approving developer app, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	t.Logf("ApproveApp")
 
 	wait(1)
 
 	got, resp, e = devapps.Get(createdApp.Name)
-  if e != nil {
+	if e != nil {
 		t.Errorf("while getting developer app, error:\n%#v\n", e)
-    return
-  }
-	if (got.Name != createdApp.Name) {
+		return
+	}
+	if got.Name != createdApp.Name {
 		t.Errorf("inconsistent name")
 	}
-	if (got.Status != "approved") {
+	if got.Status != "approved" {
 		t.Errorf("inconsistent status")
 	}
 	t.Logf("GetApp")
 
-  deletedApp, resp, e := devapps.Delete(createdApp.Name)
-  if e != nil {
+	deletedApp, resp, e := devapps.Delete(createdApp.Name)
+	if e != nil {
 		t.Errorf("while creating developer app, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	t.Logf("DeleteApp: got=%v", deletedApp)
 
-  wait(1)
+	wait(1)
 
 }

--- a/developers.go
+++ b/developers.go
@@ -1,9 +1,9 @@
 package apigee
 
 import (
-  "path"
-  "net/url"
-  "errors"
+	"errors"
+	"net/url"
+	"path"
 )
 
 const developersPath = "developers"
@@ -11,39 +11,39 @@ const developersPath = "developers"
 // DevelopersService is an interface for interfacing with the Apigee Edge Admin API
 // dealing with developers.
 type DevelopersService interface {
-  List() ([]string, *Response, error)
-  Get(string) (*Developer, *Response, error)
-  Create(Developer) (*Developer, *Response, error)
-  Update(Developer) (*Developer, *Response, error)
-  Delete(string) (*Developer, *Response, error)
-  Revoke(string) (*Response, error)
-  Approve(string) (*Response, error)
-  Apps(string) (DeveloperAppsService)
+	List() ([]string, *Response, error)
+	Get(string) (*Developer, *Response, error)
+	Create(Developer) (*Developer, *Response, error)
+	Update(Developer) (*Developer, *Response, error)
+	Delete(string) (*Developer, *Response, error)
+	Revoke(string) (*Response, error)
+	Approve(string) (*Response, error)
+	Apps(string) DeveloperAppsService
 }
 
 type DevelopersServiceOp struct {
-  client *ApigeeClient
+	client *ApigeeClient
 }
 
 var _ DevelopersService = &DevelopersServiceOp{}
 
 // Developer contains information about a registered Developer within an Edge organization.
 type Developer struct {
-  UserName         string      `json:"userName,omitempty"`
-  LastName         string      `json:"lastName,omitempty"`
-  FirstName        string      `json:"firstName,omitempty"`
-  Status           string      `json:"status,omitempty"` // active, inactive, ??
-  Attributes       Attributes  `json:"attributes,omitempty"`
-  Companies        []string    `json:"companies,omitempty"`
-  OrganizationName string      `json:"organizationName,omitempty"`
-  Email            string      `json:"email,omitempty"`
-  Id               string      `json:"uuid,omitempty"`
-  Apps             []string    `json:"apps,omitempty"`
+	UserName         string     `json:"userName,omitempty"`
+	LastName         string     `json:"lastName,omitempty"`
+	FirstName        string     `json:"firstName,omitempty"`
+	Status           string     `json:"status,omitempty"` // active, inactive, ??
+	Attributes       Attributes `json:"attributes,omitempty"`
+	Companies        []string   `json:"companies,omitempty"`
+	OrganizationName string     `json:"organizationName,omitempty"`
+	Email            string     `json:"email,omitempty"`
+	Id               string     `json:"uuid,omitempty"`
+	Apps             []string   `json:"apps,omitempty"`
 }
 
 func (s *DevelopersServiceOp) Update(dev Developer) (*Developer, *Response, error) {
 	if dev.Email == "" && dev.Id == "" {
-    return nil, nil, errors.New("must specify the Email or Id of the Developer to update")
+		return nil, nil, errors.New("must specify the Email or Id of the Developer to update")
 	}
 	// NB: it is legal to pass developer.Status, but that has no effect on the developer entity.
 	// TODO (maybe): implement updating the status.
@@ -54,98 +54,98 @@ func (s *DevelopersServiceOp) Update(dev Developer) (*Developer, *Response, erro
 		dpath = path.Join(developersPath, dev.Id)
 	}
 
-  req, e := s.client.NewRequest("POST", dpath, dev)
-  if e != nil {
-    return nil, nil, e
-  }
-  returnedDeveloper := Developer{}
-  resp, e := s.client.Do(req, &returnedDeveloper)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &returnedDeveloper, resp, e
+	req, e := s.client.NewRequest("POST", dpath, dev)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedDeveloper := Developer{}
+	resp, e := s.client.Do(req, &returnedDeveloper)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedDeveloper, resp, e
 }
 
 func (s *DevelopersServiceOp) Create(dev Developer) (*Developer, *Response, error) {
 	if dev.Id != "" {
 		return nil, nil, errors.New("cannot create a developer with a specific Id")
 	}
-  req, e := s.client.NewRequest("POST", developersPath, dev)
-  if e != nil {
-    return nil, nil, e
-  }
-  returnedDeveloper := Developer{}
-  resp, e := s.client.Do(req, &returnedDeveloper)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &returnedDeveloper, resp, e
+	req, e := s.client.NewRequest("POST", developersPath, dev)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedDeveloper := Developer{}
+	resp, e := s.client.Do(req, &returnedDeveloper)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedDeveloper, resp, e
 }
 
 func (s *DevelopersServiceOp) Delete(devEmailOrId string) (*Developer, *Response, error) {
-  path := path.Join(developersPath, devEmailOrId)
-  req, e := s.client.NewRequest("DELETE", path, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  deletedDeveloper := Developer{}
-  resp, e := s.client.Do(req, &deletedDeveloper)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &deletedDeveloper, resp, e
+	path := path.Join(developersPath, devEmailOrId)
+	req, e := s.client.NewRequest("DELETE", path, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	deletedDeveloper := Developer{}
+	resp, e := s.client.Do(req, &deletedDeveloper)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &deletedDeveloper, resp, e
 }
 
 func (s *DevelopersServiceOp) List() ([]string, *Response, error) {
-  req, e := s.client.NewRequest("GET", developersPath, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  namelist := make([]string,0)
-  resp, e := s.client.Do(req, &namelist)
-  if e != nil {
-    return nil, resp, e
-  }
-  return namelist, resp, e
+	req, e := s.client.NewRequest("GET", developersPath, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	namelist := make([]string, 0)
+	resp, e := s.client.Do(req, &namelist)
+	if e != nil {
+		return nil, resp, e
+	}
+	return namelist, resp, e
 }
 
 func (s *DevelopersServiceOp) Get(developerEmailOrId string) (*Developer, *Response, error) {
-  devPath := path.Join(developersPath, developerEmailOrId)
-  req, e := s.client.NewRequest("GET", devPath, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  returnedDeveloper := Developer{}
-  resp, e := s.client.Do(req, &returnedDeveloper)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &returnedDeveloper, resp, e
+	devPath := path.Join(developersPath, developerEmailOrId)
+	req, e := s.client.NewRequest("GET", devPath, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedDeveloper := Developer{}
+	resp, e := s.client.Do(req, &returnedDeveloper)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedDeveloper, resp, e
 }
 
-func updateDeveloperStatus (s DevelopersServiceOp, developerEmailOrId string, desiredStatus string) (*Response, error) {
+func updateDeveloperStatus(s DevelopersServiceOp, developerEmailOrId string, desiredStatus string) (*Response, error) {
 
-  devPath := path.Join(developersPath, developerEmailOrId)
+	devPath := path.Join(developersPath, developerEmailOrId)
 
-  // append the necessary query param
-  origURL, e := url.Parse(devPath)
-  if e != nil {
-     return nil, e
-  }
-  q := origURL.Query()
-  q.Add("action", desiredStatus)
-  origURL.RawQuery = q.Encode()
-  devPath = origURL.String()
+	// append the necessary query param
+	origURL, e := url.Parse(devPath)
+	if e != nil {
+		return nil, e
+	}
+	q := origURL.Query()
+	q.Add("action", desiredStatus)
+	origURL.RawQuery = q.Encode()
+	devPath = origURL.String()
 
 	req, e := s.client.NewRequest("POST", devPath, nil)
-  if e != nil {
-    return nil, e
-  }
-  resp, e := s.client.Do(req, nil)
-  if e != nil {
-    return resp, e
-  }
-  return resp, e
+	if e != nil {
+		return nil, e
+	}
+	resp, e := s.client.Do(req, nil)
+	if e != nil {
+		return resp, e
+	}
+	return resp, e
 }
 
 func (s *DevelopersServiceOp) Revoke(developerEmailOrId string) (*Response, error) {

--- a/developers_test.go
+++ b/developers_test.go
@@ -1,13 +1,13 @@
 package apigee
 
 import (
-  "encoding/json"
-  "testing"
+	"encoding/json"
 	"math/rand"
+	"testing"
 )
 
 const (
-  developerJson1 = `{
+	developerJson1 = `{
   "attributes": [ {
     "name" : "tag1",
     "value" : "created by golang" }],
@@ -20,7 +20,6 @@ const (
   "apps": []
 }`
 )
-
 
 func randomDeveloperFromTemplate() (Developer, error) {
 	got := Developer{}
@@ -37,67 +36,64 @@ func randomDeveloperFromTemplate() (Developer, error) {
 	return got, e
 }
 
-
 func TestDeveloperCreateDelete(t *testing.T) {
-  client := NewClientForTesting(t)
+	client := NewClientForTesting(t)
 	dev, e := randomDeveloperFromTemplate()
-  createdDeveloper, resp, e := client.Developers.Create(dev)
-  if e != nil {
+	createdDeveloper, resp, e := client.Developers.Create(dev)
+	if e != nil {
 		t.Errorf("while creating Edge developer, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	t.Logf("Create: got=%+v", createdDeveloper)
 	t.Logf("resp: got=%+v", resp)
 
-  wait(1)
+	wait(1)
 
-  deletedDeveloper, resp, e := client.Developers.Delete(createdDeveloper.Email)
-  if e != nil {
+	deletedDeveloper, resp, e := client.Developers.Delete(createdDeveloper.Email)
+	if e != nil {
 		t.Errorf("while deleting Edge developer, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	t.Logf("Delete: got=%v", deletedDeveloper)
 }
 
-
 func TestDeveloperList(t *testing.T) {
-  client := NewClientForTesting(t)
-  developerList, _, e := client.Developers.List()
-  if e != nil {
+	client := NewClientForTesting(t)
+	developerList, _, e := client.Developers.List()
+	if e != nil {
 		t.Errorf("while listing Edge developers, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	t.Logf("List: got=%+v", developerList)
 }
 
 func TestDeveloperGet(t *testing.T) {
-  client := NewClientForTesting(t)
-  developerList, _, e := client.Developers.List()
-  if e != nil {
+	client := NewClientForTesting(t)
+	developerList, _, e := client.Developers.List()
+	if e != nil {
 		t.Errorf("while listing Edge developers, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 
 	selectedDevEmail := developerList[rand.Intn(len(developerList))]
 
 	developerDetails, _, e := client.Developers.Get(selectedDevEmail)
-  if e != nil {
+	if e != nil {
 		t.Errorf("while getting Edge developer, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	t.Logf("Get: selected=%+v", developerDetails)
 	t.Logf("Get: email=%s", developerDetails.Email)
 }
 
-
 func TestDeveloperUpdate(t *testing.T) {
-  client := NewClientForTesting(t)
+	client := NewClientForTesting(t)
 	dev, e := randomDeveloperFromTemplate()
-  createdDeveloper, _, e := client.Developers.Create(dev)
-  if e != nil {
+	createdDeveloper, _, e := client.Developers.Create(dev)
+	if e != nil {
 		t.Errorf("while creating Edge developer, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	t.Logf("Create: got=%+v", createdDeveloper)
 	teardown := func(t *testing.T) {
 		deletedDeveloper, _, e := client.Developers.Delete(createdDeveloper.Email)
@@ -108,21 +104,21 @@ func TestDeveloperUpdate(t *testing.T) {
 		t.Logf("Delete: got=%v", deletedDeveloper)
 	}
 	defer teardown(t)
-  wait(1)
+	wait(1)
 
 	_, e = client.Developers.Revoke(createdDeveloper.Email)
-  if e != nil {
+	if e != nil {
 		t.Errorf("while revoking Edge developer, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	t.Logf("Revoke")
-  wait(1)
+	wait(1)
 
 	_, e = client.Developers.Approve(createdDeveloper.Email)
-  if e != nil {
+	if e != nil {
 		t.Errorf("while approving Edge developer, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	t.Logf("Approve")
-  wait(1)
+	wait(1)
 }

--- a/environments.go
+++ b/environments.go
@@ -1,7 +1,7 @@
 package apigee
 
 import (
-  "path"
+	"path"
 )
 
 const environmentsPath = "environments"
@@ -9,53 +9,52 @@ const environmentsPath = "environments"
 // EnvironmentsService is an interface for interfacing with the Apigee Edge Admin API
 // querying Edge environments.
 type EnvironmentsService interface {
-  List() ([]string, *Response, error)
-  Get(string) (*Environment, *Response, error)
+	List() ([]string, *Response, error)
+	Get(string) (*Environment, *Response, error)
 }
 
 type EnvironmentsServiceOp struct {
-  client *ApigeeClient
+	client *ApigeeClient
 }
 
 var _ EnvironmentsService = &EnvironmentsServiceOp{}
 
 // Environment contains information about an environment within an Edge organization.
 type Environment struct {
-  Name            string      `json:"name,omitempty"`
-  CreatedBy       string      `json:"createdBy,omitempty"`
-  CreatedAt       Timestamp   `json:"createdAt,omitempty"`
-  LastModifiedBy  string      `json:"lastModifiedBy,omitempty"`
-  LastModifiedAt  Timestamp   `json:"lastModifiedAt,omitempty"`
-  Properties      PropertyWrapper `json:"properties,omitempty"`
+	Name           string          `json:"name,omitempty"`
+	CreatedBy      string          `json:"createdBy,omitempty"`
+	CreatedAt      Timestamp       `json:"createdAt,omitempty"`
+	LastModifiedBy string          `json:"lastModifiedBy,omitempty"`
+	LastModifiedAt Timestamp       `json:"lastModifiedAt,omitempty"`
+	Properties     PropertyWrapper `json:"properties,omitempty"`
 }
-
 
 // List retrieves the list of environment names for the organization referred by the ApigeeClient.
 func (s *EnvironmentsServiceOp) List() ([]string, *Response, error) {
-  req, e := s.client.NewRequest("GET", environmentsPath, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  namelist := make([]string,0)
-  resp, e := s.client.Do(req, &namelist)
-  if e != nil {
-    return nil, resp, e
-  }
-  return namelist, resp, e
+	req, e := s.client.NewRequest("GET", environmentsPath, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	namelist := make([]string, 0)
+	resp, e := s.client.Do(req, &namelist)
+	if e != nil {
+		return nil, resp, e
+	}
+	return namelist, resp, e
 }
 
 // Get retrieves the information about an Environment in an organization, information including
 // the properties, and the created and last modified details.
 func (s *EnvironmentsServiceOp) Get(env string) (*Environment, *Response, error) {
-  path := path.Join(environmentsPath, env)
-  req, e := s.client.NewRequest("GET", path, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  returnedEnv := Environment{}
-  resp, e := s.client.Do(req, &returnedEnv)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &returnedEnv, resp, e
+	path := path.Join(environmentsPath, env)
+	req, e := s.client.NewRequest("GET", path, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedEnv := Environment{}
+	resp, e := s.client.Do(req, &returnedEnv)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedEnv, resp, e
 }

--- a/environments_test.go
+++ b/environments_test.go
@@ -1,22 +1,21 @@
 package apigee
 
 import (
-  "testing"
+	"testing"
 )
 
-const (
-)
+const ()
 
 func TestEnvList(t *testing.T) {
-  client := NewClientForTesting(t)
-  namelist, resp, e := client.Environments.List()
-  if e != nil {
+	client := NewClientForTesting(t)
+	namelist, resp, e := client.Environments.List()
+	if e != nil {
 		t.Errorf("while listing environments, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	defer resp.Body.Close()
-  if len(namelist) <= 0 {
+	if len(namelist) <= 0 {
 		t.Errorf("no environments found")
-    return
-  }
+		return
+	}
 }

--- a/organization.go
+++ b/organization.go
@@ -1,7 +1,7 @@
 package apigee
 
 import (
-  "path"
+	"path"
 )
 
 const organizationsPath = "organizations"
@@ -9,11 +9,11 @@ const organizationsPath = "organizations"
 // OrganizationsService is an interface for interfacing with the Apigee Edge Admin API
 // querying Edge environments.
 type OrganizationService interface {
-  Get(string) (*Organization, *Response, error)
+	Get(string) (*Organization, *Response, error)
 }
 
 type OrganizationServiceOp struct {
-  client *ApigeeClient
+	client *ApigeeClient
 }
 
 var _ OrganizationService = &OrganizationServiceOp{}
@@ -36,34 +36,33 @@ var _ OrganizationService = &OrganizationServiceOp{}
 // }
 
 type Organization struct {
-  LastModifiedBy  string     `json:"lastModifiedBy,omitempty"`
-  CreatedBy       string     `json:"createdBy,omitempty"`
-  LastModifiedAt  Timestamp  `json:"lastModifiedAt,omitempty"`
-  CreatedAt       Timestamp  `json:"createdAt,omitempty"`
-  DisplayName     string     `json:"displayName,omitempty"`
-  Environments    []string   `json:"environments,omitempty"`
-  Name            string     `json:"name,omitempty"`
-  Type            string     `json:"type,omitempty"`
-  Properties      PropertyWrapper `json:"properties,omitempty"`
+	LastModifiedBy string          `json:"lastModifiedBy,omitempty"`
+	CreatedBy      string          `json:"createdBy,omitempty"`
+	LastModifiedAt Timestamp       `json:"lastModifiedAt,omitempty"`
+	CreatedAt      Timestamp       `json:"createdAt,omitempty"`
+	DisplayName    string          `json:"displayName,omitempty"`
+	Environments   []string        `json:"environments,omitempty"`
+	Name           string          `json:"name,omitempty"`
+	Type           string          `json:"type,omitempty"`
+	Properties     PropertyWrapper `json:"properties,omitempty"`
 }
-
 
 // Get retrieves the information about an Organization, information including
 // the properties, and the created and last modified details, the list of Environments,
 // etc.
 func (s *OrganizationServiceOp) Get(org string) (*Organization, *Response, error) {
-  opath := ""
+	opath := ""
 	if org != "" {
 		opath = path.Join(organizationsPath, org)
 	}
-  req, e := s.client.NewRequest("GET", opath, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  returnedOrg := Organization{}
-  resp, e := s.client.Do(req, &returnedOrg)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &returnedOrg, resp, e
+	req, e := s.client.NewRequest("GET", opath, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedOrg := Organization{}
+	resp, e := s.client.Do(req, &returnedOrg)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedOrg, resp, e
 }

--- a/package_test.go
+++ b/package_test.go
@@ -1,17 +1,17 @@
 package apigee
 
 import (
-  "testing"
-  "fmt"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
+	"math/rand"
+	"testing"
 	"time"
-  "math/rand"
 )
 
 const (
-	letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	testPrefix = "go-test"
+	letterBytes    = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	testPrefix     = "go-test"
 	testConfigFile = "testdata/test_config.json"
 )
 
@@ -19,7 +19,7 @@ var apigeeClient ApigeeClient
 
 var testSettings struct {
 	Orgname string `json:"orgname"`
-	Notes string `json:"notes"`
+	Notes   string `json:"notes"`
 }
 
 func init() {
@@ -37,24 +37,24 @@ func init() {
 }
 
 func NewClientForTesting(t *testing.T) *ApigeeClient {
-  opts := &ApigeeClientOptions{Org: testSettings.Orgname, Auth: nil, Debug: false }
-  client, e := NewApigeeClient(opts)
+	opts := &ApigeeClientOptions{Org: testSettings.Orgname, Auth: nil, Debug: false}
+	client, e := NewApigeeClient(opts)
 	if e != nil {
 		t.Errorf("while initializing Edge client, error:\n%#v\n", e)
-    return nil
-  }
+		return nil
+	}
 	return client
 }
 
 func wait(delay int) {
-  fmt.Printf("Waiting %ds...\n", delay)
-  time.Sleep(time.Duration(delay)*time.Second)
+	fmt.Printf("Waiting %ds...\n", delay)
+	time.Sleep(time.Duration(delay) * time.Second)
 }
 
 func randomString(length int) string {
-    b := make([]byte, length)
-    for i := range b {
-        b[i] = letterBytes[rand.Int63() % int64(len(letterBytes))]
-    }
-    return string(b)
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
+	}
+	return string(b)
 }

--- a/products.go
+++ b/products.go
@@ -1,8 +1,8 @@
 package apigee
 
 import (
-  "path"
-  "errors"
+	"errors"
+	"path"
 )
 
 const productsPath = "apiproducts"
@@ -10,60 +10,59 @@ const productsPath = "apiproducts"
 // ProductsService is an interface for interfacing with the Apigee Edge Admin API
 // dealing with apiproducts.
 type ProductsService interface {
-  List() ([]string, *Response, error)
-  Get(string) (*ApiProduct, *Response, error)
-  Create(ApiProduct) (*ApiProduct, *Response, error)
-  Update(ApiProduct) (*ApiProduct, *Response, error)
-  Delete(string) (*ApiProduct, *Response, error)
+	List() ([]string, *Response, error)
+	Get(string) (*ApiProduct, *Response, error)
+	Create(ApiProduct) (*ApiProduct, *Response, error)
+	Update(ApiProduct) (*ApiProduct, *Response, error)
+	Delete(string) (*ApiProduct, *Response, error)
 }
 
 type ProductsServiceOp struct {
-  client *ApigeeClient
+	client *ApigeeClient
 }
 
 var _ ProductsService = &ProductsServiceOp{}
 
 // ApiProduct contains information about an API Product within an Edge organization.
 type ApiProduct struct {
-  Name            string      `json:"name,omitempty"`
-  ApiResources    []string    `json:"apiResources,omitempty"`
-  ApprovalType    string      `json:"approvalType,omitempty"`
-  Attributes      Attributes  `json:"attributes,omitempty"`
-  CreatedBy       string      `json:"createdBy,omitempty"`
-  CreatedAt       Timestamp   `json:"createdAt,omitempty"`
-  Description     string      `json:"description,omitempty"`
-  DisplayName     string      `json:"displayName,omitempty"`
-  LastModifiedBy  string      `json:"lastModifiedBy,omitempty"`
-  LastModifiedAt  Timestamp   `json:"lastModifiedAt,omitempty"`
-  Environments    []string    `json:"environments,omitempty"`
-  Proxies         []string    `json:"proxies,omitempty"`
-  Scopes          []string    `json:"scopes,omitempty"`
+	Name           string     `json:"name,omitempty"`
+	ApiResources   []string   `json:"apiResources,omitempty"`
+	ApprovalType   string     `json:"approvalType,omitempty"`
+	Attributes     Attributes `json:"attributes,omitempty"`
+	CreatedBy      string     `json:"createdBy,omitempty"`
+	CreatedAt      Timestamp  `json:"createdAt,omitempty"`
+	Description    string     `json:"description,omitempty"`
+	DisplayName    string     `json:"displayName,omitempty"`
+	LastModifiedBy string     `json:"lastModifiedBy,omitempty"`
+	LastModifiedAt Timestamp  `json:"lastModifiedAt,omitempty"`
+	Environments   []string   `json:"environments,omitempty"`
+	Proxies        []string   `json:"proxies,omitempty"`
+	Scopes         []string   `json:"scopes,omitempty"`
 }
 
 func reallyUpdateProduct(s ProductsServiceOp, product ApiProduct) (*ApiProduct, *Response, error) {
-  path := path.Join(productsPath, product.Name)
-  req, e := s.client.NewRequest("POST", path, product)
-  if e != nil {
-    return nil, nil, e
-  }
-  returnedProduct := ApiProduct{}
-  resp, e := s.client.Do(req, &returnedProduct)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &returnedProduct, resp, e
+	path := path.Join(productsPath, product.Name)
+	req, e := s.client.NewRequest("POST", path, product)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedProduct := ApiProduct{}
+	resp, e := s.client.Do(req, &returnedProduct)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedProduct, resp, e
 }
-
 
 func (s *ProductsServiceOp) Update(product ApiProduct) (*ApiProduct, *Response, error) {
 	if product.Name == "" {
-    return nil, nil, errors.New("must specify Name of ApiProduct to update")
+		return nil, nil, errors.New("must specify Name of ApiProduct to update")
 	}
 
 	if product.ApprovalType == "" || product.DisplayName == "" || product.Environments == nil {
 		// The request is lacking some required information.
 		// Must get the apiproduct first, to fill in these "required" parameters.
-    retrievedProduct, resp, e := s.Get(product.Name)
+		retrievedProduct, resp, e := s.Get(product.Name)
 		if e != nil {
 			return nil, resp, e
 		}
@@ -82,64 +81,62 @@ func (s *ProductsServiceOp) Update(product ApiProduct) (*ApiProduct, *Response, 
 	// If the caller has omitted the list of api proxies from the product,
 	// this call will update the product to have no proxies!  Likewise
 	// attributes.
-	return reallyUpdateProduct(*s, product);
+	return reallyUpdateProduct(*s, product)
 }
-
 
 func (s *ProductsServiceOp) Create(product ApiProduct) (*ApiProduct, *Response, error) {
-  req, e := s.client.NewRequest("POST", productsPath, product)
-  if e != nil {
-    return nil, nil, e
-  }
-  returnedProduct := ApiProduct{}
-  resp, e := s.client.Do(req, &returnedProduct)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &returnedProduct, resp, e
+	req, e := s.client.NewRequest("POST", productsPath, product)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedProduct := ApiProduct{}
+	resp, e := s.client.Do(req, &returnedProduct)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedProduct, resp, e
 }
 
-
 func (s *ProductsServiceOp) Delete(productName string) (*ApiProduct, *Response, error) {
-  path := path.Join(productsPath, productName)
-  req, e := s.client.NewRequest("DELETE", path, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  deletedProduct := ApiProduct{}
-  resp, e := s.client.Do(req, &deletedProduct)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &deletedProduct, resp, e
+	path := path.Join(productsPath, productName)
+	req, e := s.client.NewRequest("DELETE", path, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	deletedProduct := ApiProduct{}
+	resp, e := s.client.Do(req, &deletedProduct)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &deletedProduct, resp, e
 }
 
 // List retrieves the list of apiproduct names for the organization referred by the ApigeeClient.
 func (s *ProductsServiceOp) List() ([]string, *Response, error) {
-  req, e := s.client.NewRequest("GET", productsPath, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  namelist := make([]string,0)
-  resp, e := s.client.Do(req, &namelist)
-  if e != nil {
-    return nil, resp, e
-  }
-  return namelist, resp, e
+	req, e := s.client.NewRequest("GET", productsPath, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	namelist := make([]string, 0)
+	resp, e := s.client.Do(req, &namelist)
+	if e != nil {
+		return nil, resp, e
+	}
+	return namelist, resp, e
 }
 
 // Get retrieves the information about an API Product in an organization, information including
 // the list of API Proxies, the scopes, the quota, and other attributes.
 func (s *ProductsServiceOp) Get(productName string) (*ApiProduct, *Response, error) {
-  path := path.Join(productsPath, productName)
-  req, e := s.client.NewRequest("GET", path, nil)
-  if e != nil {
-    return nil, nil, e
-  }
-  returnedProduct := ApiProduct{}
-  resp, e := s.client.Do(req, &returnedProduct)
-  if e != nil {
-    return nil, resp, e
-  }
-  return &returnedProduct, resp, e
+	path := path.Join(productsPath, productName)
+	req, e := s.client.NewRequest("GET", path, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedProduct := ApiProduct{}
+	resp, e := s.client.Do(req, &returnedProduct)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedProduct, resp, e
 }

--- a/products_test.go
+++ b/products_test.go
@@ -1,13 +1,13 @@
 package apigee
 
 import (
-  "encoding/json"
-  "testing"
+	"encoding/json"
 	"math/rand"
+	"testing"
 )
 
 const (
-  productJson1 = `{
+	productJson1 = `{
   "apiResources" : [ ],
   "approvalType" : "auto",
   "attributes" : [ {
@@ -41,40 +41,39 @@ func randomProductFromTemplate(proxyname string) (ApiProduct, error) {
 	got.Proxies = []string{proxyname}
 	got.DisplayName = tag + "-" + got.DisplayName
 	got.Description = tag + " " + randomString(8) + " " + randomString(18)
-  got.Scopes = []string { randomString(1), randomString(2), }
+	got.Scopes = []string{randomString(1), randomString(2)}
 	return got, e
 }
 
-
 func TestProductCreateDelete(t *testing.T) {
-  client := NewClientForTesting(t)
-  namelist, resp, e := client.Proxies.List()
-  if e != nil {
+	client := NewClientForTesting(t)
+	namelist, resp, e := client.Proxies.List()
+	if e != nil {
 		t.Errorf("while listing proxies, error:\n%#v\n", e)
-    return
-  }
-  if len(namelist) <= 0 {
+		return
+	}
+	if len(namelist) <= 0 {
 		t.Errorf("no proxies found")
-    return
-  }
+		return
+	}
 
 	selectedProxy := namelist[rand.Intn(len(namelist))]
 
 	product, e := randomProductFromTemplate(selectedProxy)
-  createdProduct, resp, e := client.Products.Create(product)
-  if e != nil {
+	createdProduct, resp, e := client.Products.Create(product)
+	if e != nil {
 		t.Errorf("while creating Apigee product, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	t.Logf("Create: got=%v", createdProduct)
 	t.Logf("resp: got=%v", resp)
 
-  wait(1)
+	wait(1)
 
-  deletedProduct, resp, e := client.Products.Delete(createdProduct.Name)
-  if e != nil {
+	deletedProduct, resp, e := client.Products.Delete(createdProduct.Name)
+	if e != nil {
 		t.Errorf("while deleting Apigee product, error:\n%#v\n", e)
-    return
-  }
+		return
+	}
 	t.Logf("Delete: got=%v", deletedProduct)
 }

--- a/proxies.go
+++ b/proxies.go
@@ -5,21 +5,21 @@ const uriPathElement = "apis"
 // ProxiesService is an interface for interfacing with the Apigee Admin API
 // dealing with apiproxies.
 type ProxiesService interface {
-  List() ([]string, *Response, error)
-  Get(string) (*DeployableAsset, *Response, error)
-  Import(string, string) (*DeployableRevision, *Response, error)
-  Delete(string) (*DeletedItemInfo, *Response, error)
-  DeleteRevision(string, Revision) (*DeployableRevision, *Response, error)
-  Deploy(string,string,Revision) (*RevisionDeployment, *Response, error)
-  DeployAtPath(string,string,string,Revision) (*RevisionDeployment, *Response, error)
-  Undeploy(string,string,Revision) (*RevisionDeployment, *Response, error)
-  Export(string, Revision) (string, *Response, error)
-  GetDeployments(string) (*Deployment, *Response, error)
+	List() ([]string, *Response, error)
+	Get(string) (*DeployableAsset, *Response, error)
+	Import(string, string) (*DeployableRevision, *Response, error)
+	Delete(string) (*DeletedItemInfo, *Response, error)
+	DeleteRevision(string, Revision) (*DeployableRevision, *Response, error)
+	Deploy(string, string, Revision) (*RevisionDeployment, *Response, error)
+	DeployAtPath(string, string, string, Revision) (*RevisionDeployment, *Response, error)
+	Undeploy(string, string, Revision) (*RevisionDeployment, *Response, error)
+	Export(string, Revision) (string, *Response, error)
+	GetDeployments(string) (*Deployment, *Response, error)
 }
 
 type ProxiesServiceOp struct {
-  client *ApigeeClient
-  deployable Deployable
+	client     *ApigeeClient
+	deployable Deployable
 }
 
 var _ ProxiesService = &ProxiesServiceOp{}

--- a/proxies_test.go
+++ b/proxies_test.go
@@ -1,14 +1,14 @@
 package apigee
 
 import (
-  "testing"
-	"io/ioutil"
-  "path"
-  "os"
-  "time"
-  "strings"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
 )
 
 const (
@@ -19,7 +19,7 @@ func getProxyZipFiles(t *testing.T) []os.FileInfo {
 	entries, e := ioutil.ReadDir(proxyBundleDir)
 	if e != nil {
 		t.Errorf("while reading testdata directory, error:\n%#v\n", e)
-    return nil
+		return nil
 	}
 
 	zipfiles := []os.FileInfo{}
@@ -31,47 +31,45 @@ func getProxyZipFiles(t *testing.T) []os.FileInfo {
 
 	if len(zipfiles) <= 1 {
 		t.Errorf("not enough zipfiles in the proxyBundles directory, error:\n%#v\n", e)
-    return nil
+		return nil
 	}
 	return zipfiles
 }
-
 
 func getProxyBundleDirectories(t *testing.T) []os.FileInfo {
 	entries, e := ioutil.ReadDir(proxyBundleDir)
 	if e != nil {
 		t.Errorf("while reading testdata directory, error:\n%#v\n", e)
-    return nil
+		return nil
 	}
 
 	directories := []os.FileInfo{}
 	for i := range entries {
-		if (!strings.HasSuffix(entries[i].Name(), ".zip")) {
+		if !strings.HasSuffix(entries[i].Name(), ".zip") {
 			directories = append(directories, entries[i])
 		}
 	}
 
 	if len(directories) <= 1 {
 		t.Errorf("not enough directories in the proxyBundles directory, error:\n%#v\n", e)
-    return nil
+		return nil
 	}
 
 	return directories
 }
 
-
 func getEnvironments(t *testing.T, client *ApigeeClient) []string {
-// get environments
-  envlist, resp, e := client.Environments.List()
-  if e != nil {
+	// get environments
+	envlist, resp, e := client.Environments.List()
+	if e != nil {
 		t.Errorf("while listing environments, error:\n%#v\n", e)
-    return nil
-  }
+		return nil
+	}
 	defer resp.Body.Close()
-  if len(envlist) <= 0 {
+	if len(envlist) <= 0 {
 		t.Errorf("no environments found")
-    return nil
-  }
+		return nil
+	}
 
 	filteredEnvList := []string{}
 	for i := range envlist {
@@ -90,7 +88,7 @@ func TestProxyImportFromZip(t *testing.T) {
 		now.Hour(), now.Minute(), now.Second())
 
 	zipfiles := getProxyZipFiles(t)
-  client := NewClientForTesting(t)
+	client := NewClientForTesting(t)
 
 	for _, zipfile := range zipfiles {
 		fullFileName := path.Join(proxyBundleDir, zipfile.Name())
@@ -112,9 +110,8 @@ func TestProxyImportFromZip(t *testing.T) {
 	}
 }
 
-
 func TestProxyImportFromDir(t *testing.T) {
-  client := NewClientForTesting(t)
+	client := NewClientForTesting(t)
 
 	now := time.Now()
 	timestamp := fmt.Sprintf("%d%02d%02d-%02d%02d%02d",
@@ -142,39 +139,38 @@ func TestProxyImportFromDir(t *testing.T) {
 	}
 }
 
-
 func TestProxyList(t *testing.T) {
-  client := NewClientForTesting(t)
+	client := NewClientForTesting(t)
 
 	proxies, resp, e := client.Proxies.List()
 	if e != nil {
 		t.Errorf("while listing proxies, error:\n%#v\n", e)
-    return
+		return
 	}
 	defer resp.Body.Close()
 	if resp.Status != "200 OK" {
 		t.Errorf("while listing, status: %#v\n", resp.Status)
 		return
 	}
-	if len(proxies) ==0 {
+	if len(proxies) == 0 {
 		t.Errorf("no proxies returned while listing")
 		return
 	}
 }
 
 func TestProxyGet(t *testing.T) {
-  client := NewClientForTesting(t)
+	client := NewClientForTesting(t)
 	proxies, resp, e := client.Proxies.List()
 	if e != nil {
 		t.Errorf("while listing proxies, error:\n%#v\n", e)
-    return
+		return
 	}
 	defer resp.Body.Close()
 	if resp.Status != "200 OK" {
 		t.Errorf("while listing, status: %#v\n", resp.Status)
 		return
 	}
-	if len(proxies) ==0 {
+	if len(proxies) == 0 {
 		t.Errorf("no proxies returned while listing")
 		return
 	}
@@ -205,8 +201,8 @@ func TestProxyGet(t *testing.T) {
 
 type ImportedProxyStruct struct {
 	proxyName string
-	env string
-	rev Revision
+	env       string
+	rev       Revision
 }
 
 func TestProxyDeployUndeploy(t *testing.T) {
@@ -215,7 +211,7 @@ func TestProxyDeployUndeploy(t *testing.T) {
 		now.Year(), now.Month(), now.Day(),
 		now.Hour(), now.Minute(), now.Second())
 
-  client := NewClientForTesting(t)
+	client := NewClientForTesting(t)
 	zipfiles := getProxyZipFiles(t)
 	environmentList := getEnvironments(t, client)
 	importedProxies := []ImportedProxyStruct{}
@@ -238,7 +234,7 @@ func TestProxyDeployUndeploy(t *testing.T) {
 
 		randomPath := fmt.Sprintf("/%s-deploy", timestamp)
 		env := environmentList[rand.Intn(len(environmentList))]
-		importedProxies = append(importedProxies, ImportedProxyStruct{proxyName:proxyName, env:env, rev:proxyRev.Revision})
+		importedProxies = append(importedProxies, ImportedProxyStruct{proxyName: proxyName, env: env, rev: proxyRev.Revision})
 		deployment, resp, e := client.Proxies.DeployAtPath(proxyName, randomPath, env, proxyRev.Revision)
 		if e != nil {
 			t.Errorf("while deploying, error:\n%#v\n", e)
@@ -267,13 +263,12 @@ func TestProxyDeployUndeploy(t *testing.T) {
 	}
 }
 
-
 func TestProxyInquireDeployment(t *testing.T) {
 	now := time.Now()
 	timestamp := fmt.Sprintf("%d%02d%02d-%02d%02d%02d",
 		now.Year(), now.Month(), now.Day(),
 		now.Hour(), now.Minute(), now.Second())
-  client := NewClientForTesting(t)
+	client := NewClientForTesting(t)
 	zipfiles := getProxyZipFiles(t)
 	selectedZip := zipfiles[rand.Intn(len(zipfiles))]
 	environmentList := getEnvironments(t, client)
@@ -356,13 +351,12 @@ func TestProxyInquireDeployment(t *testing.T) {
 	t.Logf("undeployed: %#v\n", revisionDeployment)
 }
 
-
 func TestProxyDelete(t *testing.T) {
-  client := NewClientForTesting(t)
+	client := NewClientForTesting(t)
 	proxies, resp, e := client.Proxies.List()
 	if e != nil {
 		t.Errorf("while listing proxies, error:\n%#v\n", e)
-    return
+		return
 	}
 	defer resp.Body.Close()
 	if resp.Status != "200 OK" {
@@ -430,14 +424,13 @@ func TestProxyDelete(t *testing.T) {
 	}
 }
 
-
 func TestProxyDeleteFail(t *testing.T) {
 	now := time.Now()
 	timestamp := fmt.Sprintf("%d%02d%02d-%02d%02d%02d",
 		now.Year(), now.Month(), now.Day(),
 		now.Hour(), now.Minute(), now.Second())
 
-  client := NewClientForTesting(t)
+	client := NewClientForTesting(t)
 	zipfiles := getProxyZipFiles(t)
 	selectedZip := zipfiles[rand.Intn(len(zipfiles))]
 	environmentList := getEnvironments(t, client)

--- a/revision.go
+++ b/revision.go
@@ -1,9 +1,9 @@
 package apigee
 
 import (
-  "strconv"
-  "strings"
-  "fmt"
+	"fmt"
+	"strconv"
+	"strings"
 )
 
 // Revision represents a revision number. Edge returns rev numbers in string form.
@@ -13,21 +13,21 @@ type Revision int
 // MarshalJSON implements the json.Marshaler interface. It marshals from
 // a Revision holding an integer value like 2, into a string like "2".
 func (r *Revision) MarshalJSON() ([]byte, error) {
-  rev := fmt.Sprintf("%d", r)
-  return []byte(rev), nil
+	rev := fmt.Sprintf("%d", r)
+	return []byte(rev), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface. It unmarshals from
 // a string like "2" (including the quotes), into an integer 2.
 func (r *Revision) UnmarshalJSON(b []byte) error {
-  rev, e := strconv.ParseInt(strings.TrimSuffix(strings.TrimPrefix(string(b),"\""),"\""), 10, 32)
-  if e != nil {
-    return e
-  }
-  *r = Revision(rev)
-  return nil
+	rev, e := strconv.ParseInt(strings.TrimSuffix(strings.TrimPrefix(string(b), "\""), "\""), 10, 32)
+	if e != nil {
+		return e
+	}
+	*r = Revision(rev)
+	return nil
 }
 
 func (r Revision) String() string {
-  return fmt.Sprintf("%d", r)
+	return fmt.Sprintf("%d", r)
 }

--- a/targetservers.go
+++ b/targetservers.go
@@ -1,0 +1,134 @@
+package apigee
+
+import (
+	"errors"
+	"fmt"
+	"path"
+)
+
+const targetserversPath = "targetservers"
+
+// TargetserversService is an interface for interfacing with the Apigee Edge Admin API
+// dealing with Target servers
+type TargetserversService interface {
+	List(string) ([]string, *Response, error)
+	Get(string, string) (*TargetServer, *Response, error)
+	Create(TargetServer, string) (*TargetServer, *Response, error)
+	Update(TargetServer, string) (*TargetServer, *Response, error)
+	Delete(string, string) (*TargetServer, *Response, error)
+}
+
+// TargetserversServiceOp represents the target server service used to
+// communicate with Apigee
+type TargetserversServiceOp struct {
+	client *ApigeeClient
+}
+
+var _ TargetserversService = &TargetserversServiceOp{}
+
+// TargetServer contains information about a Target Server withing an environment in an Edge Organization
+type TargetServer struct {
+	Name      string `json:"name"`
+	Host      string `json:"host"`
+	Port      int    `json:"port"`
+	IsEnabled bool   `json:"isEnabled"`
+	SSLInfo   struct {
+		Ciphers                []interface{} `json:"ciphers,omitempty"`
+		ClientAuthEnabled      bool          `json:"clientAuthEnabled,omitempty"`
+		Enabled                bool          `json:"enabled,omitempty"`
+		IgnoreValidationErrors bool          `json:"ignoreValidationErrors,omitempty"`
+		KeyAlias               string        `json:"keyAlias,omitempty"`
+		KeyStore               string        `json:"keyStore,omitempty"`
+		Protocols              []interface{} `json:"protocols,omitempty"`
+		TrustStore             string        `json:"trustStore,omitempty"`
+	} `json:"SSLInfo,omitempty"`
+}
+
+//List retrieves the list of Target servers from a specific environment env
+func (s *TargetserversServiceOp) List(env string) ([]string, *Response, error) {
+	var p1 string
+	p1 = path.Join("e", env, targetserversPath)
+	req, e := s.client.NewRequest("GET", p1, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	targetserverlist := make([]string, 0)
+	resp, e := s.client.Do(req, &targetserverlist)
+	if e != nil {
+		return nil, resp, e
+	}
+	return targetserverlist, resp, e
+}
+
+//Get retrieves a specific Target server from a specific environment env
+func (s *TargetserversServiceOp) Get(name, env string) (*TargetServer, *Response, error) {
+	var p1 string
+	p1 = path.Join("e", env, targetserversPath, name)
+	req, e := s.client.NewRequest("GET", p1, nil)
+	if e != nil {
+		return nil, nil, e
+	}
+	returnedtargetserver := TargetServer{}
+	resp, e := s.client.Do(req, &returnedtargetserver)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedtargetserver, resp, e
+}
+
+//Create creates a new target server in the given environment
+func (s *TargetserversServiceOp) Create(targetserver TargetServer, env string) (*TargetServer, *Response, error) {
+	var p1 string
+
+	p1 = path.Join("e", env, targetserversPath)
+
+	fmt.Printf("argumnets are %v, %v", targetserver, env)
+	req, e := s.client.NewRequest("POST", p1, targetserver)
+	if e != nil {
+		return nil, nil, e
+	}
+
+	returnedtargetserver := TargetServer{}
+	resp, e := s.client.Do(req, &returnedtargetserver)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedtargetserver, resp, e
+}
+
+//Update updates a target server in the given environment
+func (s *TargetserversServiceOp) Update(targetserver TargetServer, env string) (*TargetServer, *Response, error) {
+	var p1 string
+
+	if targetserver.Name == "" || targetserver.Host == "" || targetserver.Port == 0 {
+		return nil, nil, errors.New("Must specify the name, host and port of the target server to update")
+	}
+
+	p1 = path.Join("e", env, targetserversPath, targetserver.Name)
+	req, e := s.client.NewRequest("PUT", p1, targetserver)
+	if e != nil {
+		return nil, nil, e
+	}
+
+	returnedtargetserver := TargetServer{}
+	resp, e := s.client.Do(req, &returnedtargetserver)
+	if e != nil {
+		return nil, resp, e
+	}
+	return &returnedtargetserver, resp, e
+}
+
+//Delete deletes a target server in the given environment
+func (s *TargetserversServiceOp) Delete(name, env string) (*TargetServer, *Response, error) {
+	var p1 string
+	p1 = path.Join("e", env, targetserversPath, name)
+	req, e := s.client.NewRequest("DELETE", p1, nil)
+	deletedtargetserver := TargetServer{}
+
+	resp, e := s.client.Do(req, &deletedtargetserver)
+
+	if e != nil {
+		return nil, resp, e
+	}
+	return &deletedtargetserver, resp, e
+}

--- a/targetservers.go
+++ b/targetservers.go
@@ -81,8 +81,6 @@ func (s *TargetserversServiceOp) Create(targetserver TargetServer, env string) (
 	var p1 string
 
 	p1 = path.Join("e", env, targetserversPath)
-
-	fmt.Printf("argumnets are %v, %v", targetserver, env)
 	req, e := s.client.NewRequest("POST", p1, targetserver)
 	if e != nil {
 		return nil, nil, e

--- a/timespan.go
+++ b/timespan.go
@@ -1,20 +1,19 @@
 package apigee
 
 import (
-  "errors"
-  "strings"
-  "time"
-  "strconv"
-  "fmt"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
 )
 
 // Timespan represents a timespan that can be parsed from a string like "3d"
 // meaning "3 days". It will typically be serialized as milliseconds =
 // milliseconds-since-unix-epoch.
 type Timespan struct {
-  time.Duration
+	time.Duration
 }
-
 
 func NewTimespan(initializer string) *Timespan {
 	initializer = strings.ToLower(initializer)
@@ -30,8 +29,8 @@ func NewTimespan(initializer string) *Timespan {
 }
 
 func (span Timespan) MarshalJSON() ([]byte, error) {
-  s := fmt.Sprintf("%0.f", span.Duration.Seconds()*1000)
-  return []byte(s), nil
+	s := fmt.Sprintf("%0.f", span.Duration.Seconds()*1000)
+	return []byte(s), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
@@ -41,5 +40,5 @@ func (span *Timespan) UnmarshalJSON(b []byte) error {
 }
 
 func (span Timespan) String() string {
-  return span.String()
+	return span.String()
 }

--- a/timespan_test.go
+++ b/timespan_test.go
@@ -1,38 +1,37 @@
 package apigee
 
 import (
-  "encoding/json"
-  //"fmt"
-  "testing"
+	"encoding/json"
+	//"fmt"
+	"testing"
 )
 
-
 func TestTimespan_New(t *testing.T) {
-  testCases := []struct {
-    input     string
-    expected  string
-  }{
-    {"1s", "1000"},
-    {"1m", "60000"},
-    {"3m", "180000"},
-    {"1h", "3600000"},
-    {"1d", "86400000"},
-    {"10d", "864000000"},
-  }
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"1s", "1000"},
+		{"1m", "60000"},
+		{"3m", "180000"},
+		{"1h", "3600000"},
+		{"1d", "86400000"},
+		{"10d", "864000000"},
+	}
 
-  for _, tc := range testCases {
-    ts := NewTimespan(tc.input)
-    // if (e != nil) {
-    //   t.Errorf("%s: error=%v", tc.input, e)
-    // }
-    //actualOutput := ts.String()
-    actualOutput, e := json.Marshal(ts)
-    if (e != nil) {
-      t.Errorf("%s: error=%v", tc.input, e)
-    }
-    got := string(actualOutput)
-    if got != tc.expected {
-      t.Errorf("%s: value[actual=%s, expected=%s]", tc.input, got, tc.expected)
-    }
-  }
+	for _, tc := range testCases {
+		ts := NewTimespan(tc.input)
+		// if (e != nil) {
+		//   t.Errorf("%s: error=%v", tc.input, e)
+		// }
+		//actualOutput := ts.String()
+		actualOutput, e := json.Marshal(ts)
+		if e != nil {
+			t.Errorf("%s: error=%v", tc.input, e)
+		}
+		got := string(actualOutput)
+		if got != tc.expected {
+			t.Errorf("%s: value[actual=%s, expected=%s]", tc.input, got, tc.expected)
+		}
+	}
 }

--- a/timestamp.go
+++ b/timestamp.go
@@ -1,39 +1,39 @@
 package apigee
 
 import (
-  "strconv"
-  "time"
-  "fmt"
+	"fmt"
+	"strconv"
+	"time"
 )
 
 // Timestamp represents a time that can be unmarshalled from a JSON string
 // formatted as "java time" = milliseconds-since-unix-epoch.
 type Timestamp struct {
-  time.Time
+	time.Time
 }
 
 func (t Timestamp) MarshalJSON() ([]byte, error) {
-  ms := t.Time.UnixNano() / 1000000
-  stamp := fmt.Sprintf("%d", ms)
-  return []byte(stamp), nil
+	ms := t.Time.UnixNano() / 1000000
+	stamp := fmt.Sprintf("%d", ms)
+	return []byte(stamp), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 // Time is expected in RFC3339 or Unix format.
 func (t *Timestamp) UnmarshalJSON(b []byte) error {
-  ms, err := strconv.ParseInt(string(b), 10, 64)
-  if err != nil {
-    return err
-  }
-  t.Time = time.Unix(int64(ms/1000), (ms - int64(ms/1000)*1000) * 1000000)
-  return nil
+	ms, err := strconv.ParseInt(string(b), 10, 64)
+	if err != nil {
+		return err
+	}
+	t.Time = time.Unix(int64(ms/1000), (ms-int64(ms/1000)*1000)*1000000)
+	return nil
 }
 
 func (t Timestamp) String() string {
-  return fmt.Sprintf("%d", int64(t.Time.UnixNano()) / 1000000)
+	return fmt.Sprintf("%d", int64(t.Time.UnixNano())/1000000)
 }
 
 // Equal reports whether t and u are equal based on time.Equal
 func (t Timestamp) Equal(u Timestamp) bool {
-  return t.Time.Equal(u.Time)
+	return t.Time.Equal(u.Time)
 }

--- a/timestamp_test.go
+++ b/timestamp_test.go
@@ -1,102 +1,100 @@
 package apigee
 
 import (
-  "encoding/json"
-  //"fmt"
-  "testing"
-  "time"
+	"encoding/json"
+	//"fmt"
+	"testing"
+	"time"
 )
 
 const (
-  lastModifiedMs = `1444426707423`
-  originMs = `0`
-  workStartMs = `1343752707000`
-  referenceTimeStr = `1473275339334`
+	lastModifiedMs   = `1444426707423`
+	originMs         = `0`
+	workStartMs      = `1343752707000`
+	referenceTimeStr = `1473275339334`
 )
 
 var (
-  lastModifiedTime = time.Date(2015, 10, 9, 21, 38, 27, 423*1000000, time.UTC)
-  unixOriginTime   = time.Unix(0, 0).In(time.UTC)
-  workStartDate    = time.Date(2012, 7, 31, 16, 38, 27, 0, time.UTC)
-  referenceTime    = time.Date(2016, 9, 7, 19, 8, 59, 334*1000000, time.UTC)
+	lastModifiedTime = time.Date(2015, 10, 9, 21, 38, 27, 423*1000000, time.UTC)
+	unixOriginTime   = time.Unix(0, 0).In(time.UTC)
+	workStartDate    = time.Date(2012, 7, 31, 16, 38, 27, 0, time.UTC)
+	referenceTime    = time.Date(2016, 9, 7, 19, 8, 59, 334*1000000, time.UTC)
 )
 
 func TestTimestamp_Marshal(t *testing.T) {
-  testCases := []struct {
-    desc      string
-    data      Timestamp
-    expected  string
-    wantErr   bool
-    equal     bool
-  }{
-    {"lastModified ", Timestamp{lastModifiedTime}, lastModifiedMs, false, true},
-    {"origin       ", Timestamp{unixOriginTime}, originMs, false, true},
-    {"workStartDate", Timestamp{workStartDate}, originMs, false, false},
-    {"workStartDate", Timestamp{workStartDate}, workStartMs, false, true},
-  }
+	testCases := []struct {
+		desc     string
+		data     Timestamp
+		expected string
+		wantErr  bool
+		equal    bool
+	}{
+		{"lastModified ", Timestamp{lastModifiedTime}, lastModifiedMs, false, true},
+		{"origin       ", Timestamp{unixOriginTime}, originMs, false, true},
+		{"workStartDate", Timestamp{workStartDate}, originMs, false, false},
+		{"workStartDate", Timestamp{workStartDate}, workStartMs, false, true},
+	}
 
-  for _, tc := range testCases {
-    out, err := json.Marshal(tc.data)
-    if gotErr := (err != nil); gotErr != tc.wantErr {
-      t.Errorf("%s: gotErr=%v, wantErr=%v, err=%v", tc.desc, gotErr, tc.wantErr, err)
-    }
-    got := string(out)
-    equal := got == tc.expected
-    if (got == tc.expected) != tc.equal {
-      t.Errorf("%s: value[actual=%s, expected=%s], equal[actual=%v, expected=%v]", tc.desc, got, tc.expected, equal, tc.equal)
-    }
-  }
+	for _, tc := range testCases {
+		out, err := json.Marshal(tc.data)
+		if gotErr := (err != nil); gotErr != tc.wantErr {
+			t.Errorf("%s: gotErr=%v, wantErr=%v, err=%v", tc.desc, gotErr, tc.wantErr, err)
+		}
+		got := string(out)
+		equal := got == tc.expected
+		if (got == tc.expected) != tc.equal {
+			t.Errorf("%s: value[actual=%s, expected=%s], equal[actual=%v, expected=%v]", tc.desc, got, tc.expected, equal, tc.equal)
+		}
+	}
 }
-
 
 func TestTimestamp_Unmarshal(t *testing.T) {
-  testCases := []struct {
-    desc      string
-    data      string
-    expected  Timestamp
-    wantErr   bool
-    equal     bool
-  }{
-    {"Reference    ", referenceTimeStr, Timestamp{referenceTime}, false, true},
-    {"Mismatch     ", referenceTimeStr, Timestamp{}, false, false},
-  }
-  for _, tc := range testCases {
-    var got Timestamp
-    err := json.Unmarshal([]byte(tc.data), &got)
-    t.Logf("%s: got=%v", tc.desc, got)
-    t.Logf("%s: got=%v", tc.desc, got.Time.String())
-    if gotErr := err != nil; gotErr != tc.wantErr {
-      t.Errorf("%s: gotErr=%v, wantErr=%v, err=%v", tc.desc, gotErr, tc.wantErr, err)
-      continue
-    }
-    equal := got.Equal(tc.expected)
-    if equal != tc.equal {
-      t.Errorf("%s: values[got=%#v, expected=%#v], equal[got=%v, expected=%v]", tc.desc, got, tc.expected, equal, tc.equal)
-    }
-  }
+	testCases := []struct {
+		desc     string
+		data     string
+		expected Timestamp
+		wantErr  bool
+		equal    bool
+	}{
+		{"Reference    ", referenceTimeStr, Timestamp{referenceTime}, false, true},
+		{"Mismatch     ", referenceTimeStr, Timestamp{}, false, false},
+	}
+	for _, tc := range testCases {
+		var got Timestamp
+		err := json.Unmarshal([]byte(tc.data), &got)
+		t.Logf("%s: got=%v", tc.desc, got)
+		t.Logf("%s: got=%v", tc.desc, got.Time.String())
+		if gotErr := err != nil; gotErr != tc.wantErr {
+			t.Errorf("%s: gotErr=%v, wantErr=%v, err=%v", tc.desc, gotErr, tc.wantErr, err)
+			continue
+		}
+		equal := got.Equal(tc.expected)
+		if equal != tc.equal {
+			t.Errorf("%s: values[got=%#v, expected=%#v], equal[got=%v, expected=%v]", tc.desc, got, tc.expected, equal, tc.equal)
+		}
+	}
 }
 
-
 func TestTimestamp_MarshalReflexivity(t *testing.T) {
-  testCases := []struct {
-    desc string
-    data Timestamp
-  }{
-    {"Reference", Timestamp{referenceTime}},
-    {"WorkStart", Timestamp{workStartDate}},
-    {"UnixOrigin", Timestamp{unixOriginTime}},
-    {"Empty", Timestamp{}}, // degenerate case.  I don't really care about this; it will never happen.
-  }
-  for _, tc := range testCases {
-    data, err := json.Marshal(tc.data)
-    if err != nil {
-      t.Errorf("%s: Marshal err=%v", tc.desc, err)
-    }
-    var got Timestamp
-    err = json.Unmarshal(data, &got)
-    t.Logf("%s: %+v ?= %s", tc.desc, got, string(data))
-    if got.String() != tc.data.String() {
-      t.Errorf("%s: %+v != %+v", tc.desc, got, data)
-    }
-  }
+	testCases := []struct {
+		desc string
+		data Timestamp
+	}{
+		{"Reference", Timestamp{referenceTime}},
+		{"WorkStart", Timestamp{workStartDate}},
+		{"UnixOrigin", Timestamp{unixOriginTime}},
+		{"Empty", Timestamp{}}, // degenerate case.  I don't really care about this; it will never happen.
+	}
+	for _, tc := range testCases {
+		data, err := json.Marshal(tc.data)
+		if err != nil {
+			t.Errorf("%s: Marshal err=%v", tc.desc, err)
+		}
+		var got Timestamp
+		err = json.Unmarshal(data, &got)
+		t.Logf("%s: %+v ?= %s", tc.desc, got, string(data))
+		if got.String() != tc.data.String() {
+			t.Errorf("%s: %+v != %+v", tc.desc, got, data)
+		}
+	}
 }


### PR DESCRIPTION
Added Support for TargetServers.
Following methods have been added for the operations on target servers.

1. List - Get the list of all target servers from a given environment
2. Get - Get a specific target server from a given environment
3. Create - Create a new target sever in a given environment
4. Update - Update a specific target server in a given environment
5. Delete - Delete a specific target sever in a given environment

@DinoChiesa Please review and would be great to hear back the feedbacks from you
